### PR TITLE
FIX: Rename aabb rect drawing procedures to aa

### DIFF
--- a/coresdk/src/backend/graphics_driver.cpp
+++ b/coresdk/src/backend/graphics_driver.cpp
@@ -902,7 +902,7 @@ unsigned int _sk_renderer_count(sk_drawing_surface *surface)
 //  Rectangles
 //
 
-void sk_draw_aabb_rect(sk_drawing_surface *surface, sk_color clr, float x, float y, float width, float height)
+void sk_draw_aa_rect(sk_drawing_surface *surface, sk_color clr, float x, float y, float width, float height)
 {
     if ( (! surface) || (! surface->_data) ) return;
 
@@ -930,7 +930,7 @@ void sk_draw_aabb_rect(sk_drawing_surface *surface, sk_color clr, float x, float
     }
 }
 
-void sk_fill_aabb_rect(sk_drawing_surface *surface, sk_color clr, float x, float y, float width, float height)
+void sk_fill_aa_rect(sk_drawing_surface *surface, sk_color clr, float x, float y, float width, float height)
 {
     if ( (! surface) || (! surface->_data)  ) return;
     

--- a/coresdk/src/backend/graphics_driver.h
+++ b/coresdk/src/backend/graphics_driver.h
@@ -61,8 +61,8 @@ void sk_close_drawing_surface(sk_drawing_surface *surface);
 void sk_clear_drawing_surface(sk_drawing_surface *surface, sk_color clr);
 void sk_refresh_window(sk_drawing_surface *window);
 
-void sk_draw_aabb_rect(sk_drawing_surface *surface, sk_color clr, float x, float y, float width, float height);
-void sk_fill_aabb_rect(sk_drawing_surface *surface, sk_color clr, float x, float y, float width, float height);
+void sk_draw_aa_rect(sk_drawing_surface *surface, sk_color clr, float x, float y, float width, float height);
+void sk_fill_aa_rect(sk_drawing_surface *surface, sk_color clr, float x, float y, float width, float height);
 void sk_draw_rect(sk_drawing_surface *surface, sk_color clr, float *data, int data_sz);
 void sk_fill_rect(sk_drawing_surface *surface, sk_color clr, float *data, int data_sz);
 

--- a/coresdk/src/coresdk/graphics.cpp
+++ b/coresdk/src/coresdk/graphics.cpp
@@ -140,7 +140,7 @@ void draw_rectangle(color clr, float x, float y, float width, float height, draw
         }
         
         xy_from_opts(opts, x, y);
-        sk_draw_aabb_rect(surface, clr, x, y, width, height);
+        sk_draw_aa_rect(surface, clr, x, y, width, height);
     }
 }
 
@@ -172,7 +172,7 @@ void fill_rectangle(color clr, float x, float y, float width, float height, draw
         }
         
         xy_from_opts(opts, x, y);
-        sk_fill_aabb_rect(surface, clr, x, y, width, height);
+        sk_fill_aa_rect(surface, clr, x, y, width, height);
     }
 }
 


### PR DESCRIPTION
FIX some graphics procedures were named aabb incorrectly. This renames them all to aa