### PR TITLE
FIX: rename aabb graphics procedures to aa

### DIFF
--- a/coresdk/src/coresdk/text.cpp
+++ b/coresdk/src/coresdk/text.cpp
@@ -113,7 +113,7 @@ void _print_strings(void *dest, font fnt, string str, rectangle rc, color fg_clr
 {
     if (bg_clr.a > 0)
     {
-        sk_fill_aabb_rect(to_surface_ptr(dest), bg_clr, rc.x, rc.y, rc.width, rc.height);
+        sk_fill_aa_rect(to_surface_ptr(dest), bg_clr, rc.x, rc.y, rc.width, rc.height);
     }
     
     sk_draw_text(to_surface_ptr(dest), &fnt->font, rc.x, rc.y, str.c_str(), fg_clr);


### PR DESCRIPTION
FIX missed an instance of an aabb procedure last commit