### PR TITLE
FEATURE: Change font methods to take a font size for most operations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ Temporary Items
 ## Build generated
 build/
 DerivedData/
+test_database
 
 ## Various settings
 *.pbxuser
@@ -66,3 +67,17 @@ coresdk/external/SDL_ttf
 coresdk/external/setup.log
 coresdk/include
 projects/bash/out
+
+### CLion JetBrains IDE ###
+.idea
+CMakeLists.txt
+
+### vim ###
+swap
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+# temporary
+.netrwhist
+*~
+# auto-generated tag files
+tags

--- a/coresdk/src/backend/backend_types.h
+++ b/coresdk/src/backend/backend_types.h
@@ -145,18 +145,14 @@ struct _bitmap_data
     bool *pixel_mask;   // Pixel mask used for pixel level collisions
 };
 
-enum sk_font_kind
-{
-    SKFT_UNKNOWN = 0,
-    SKFT_TTF = 1
-};
-
 struct sk_font_data
 {
-    sk_font_kind kind;
-    
-    // private data used by backend
-    void * _data;
+    pointer_identifier  id;
+    string              name;
+    string              filename;
+
+    // TTF_Font Private Data
+    map<int, void *> _data;
 };
 
 enum sk_http_method

--- a/coresdk/src/backend/text_driver.cpp
+++ b/coresdk/src/backend/text_driver.cpp
@@ -50,22 +50,6 @@ sk_font_data* sk_load_font(const char * filename, int font_size)
     return font;
 }
 
-void sk_add_font_size(sk_font_data *font, int font_size) {
-    if (VALID_PTR(font, FONT_PTR) and font->_data.count(font_size) == 0)
-    {
-        font->_data[font_size] = TTF_OpenFont(font->filename.c_str(), font_size);
-
-        if (!font->_data[font_size])
-        {
-            cerr << "Error loading font " << SDL_GetError() << endl;
-        }
-    }
-    else
-    {
-        cerr << "Trying to load font size for an invalid font" << endl;
-    }
-}
-
 /**
  * Returns the font for the given size. Loads the font size if not loaded.
  */
@@ -85,6 +69,11 @@ TTF_Font* _get_font(sk_font_data* font, int font_size)
             // Load the font for the given size.
             ttf_font = TTF_OpenFont(font->filename.c_str(), font_size);
             font->_data[font_size] = ttf_font;
+
+            if (!font->_data[font_size])
+            {
+                cerr << "Error loading font " << SDL_GetError() << endl;
+            }
         }
     }
     else
@@ -93,6 +82,10 @@ TTF_Font* _get_font(sk_font_data* font, int font_size)
     }
 
     return ttf_font;
+}
+
+void sk_add_font_size(sk_font_data *font, int font_size) {
+    _get_font(font, font_size);
 }
 
 bool sk_contains_valid_font(sk_font_data* font)

--- a/coresdk/src/backend/text_driver.cpp
+++ b/coresdk/src/backend/text_driver.cpp
@@ -68,6 +68,13 @@ TTF_Font* _get_font(sk_font_data* font, int font_size)
         {
             // Load the font for the given size.
             ttf_font = TTF_OpenFont(font->filename.c_str(), font_size);
+
+            if (font->_data.size() > 0)
+            {
+                int font_style = TTF_GetFontStyle(static_cast<TTF_Font*>(font->_data.begin()->second));
+                TTF_SetFontStyle(ttf_font, font_style);
+            }
+
             font->_data[font_size] = ttf_font;
 
             if (!font->_data[font_size])

--- a/coresdk/src/backend/text_driver.cpp
+++ b/coresdk/src/backend/text_driver.cpp
@@ -45,17 +45,27 @@ sk_font_data* sk_load_font(const char * filename, int font_size)
     font->id = FONT_PTR;
     font->filename = filename;
 
-    printf("Before\n");
-    font->_data[font_size] = TTF_OpenFont(filename, font_size);
-    printf("Seg fault here?\n");
-    if (!font->_data[font_size])
-    {
-        cerr << "Error loading font " << SDL_GetError() << endl;
-    }
+    sk_add_font_size(font, font_size);
+
     return font;
 }
 
-bool sk_contains_valid_font(sk_font_data* font) {
+void sk_add_font_size(sk_font_data *font, int font_size) {
+    if (VALID_PTR(font, FONT_PTR))
+    {
+        font->_data[font_size] = TTF_OpenFont(font->filename.c_str(), font_size);
+        if (!font->_data[font_size]) {
+            cerr << "Error loading font " << SDL_GetError() << endl;
+        }
+    }
+    else
+    {
+        cerr << "Trying to load font size for an invalid font" << endl;
+    }
+}
+
+bool sk_contains_valid_font(sk_font_data* font)
+{
     for (auto const it : font->_data) {
         if (it.second) {
             return true;
@@ -78,6 +88,10 @@ void sk_close_font(sk_font_data* font)
 
         font->name = "";
         font->id = NONE_PTR;
+    }
+    else
+    {
+        cerr << "Trying to close font that is not a valid font." << endl;
     }
 }
 
@@ -160,7 +174,9 @@ void sk_draw_text(
     if (! (VALID_PTR(font, FONT_PTR))) return; // error with font
 
     // Check that the font size has been loaded and create if not
-    font->_data[font_size] = TTF_OpenFont(font->filename.c_str(), font_size);
+    if (font->_data.count(font_size) == 0) {
+        font->_data[font_size] = TTF_OpenFont(font->filename.c_str(), font_size);
+    }
 
     SDL_Surface * text_surface = NULL;
     SDL_Texture * text_texture = NULL;

--- a/coresdk/src/backend/text_driver.h
+++ b/coresdk/src/backend/text_driver.h
@@ -15,12 +15,13 @@ void sk_init_text();
 void sk_finalize_text();
 
 
-sk_font_data sk_load_font(const char * filename, int font_size);
+sk_font_data* sk_load_font(const char * filename, int font_size);
+bool sk_contains_valid_font(sk_font_data* font);
 void sk_close_font(sk_font_data* font);
-int sk_text_line_skip(sk_font_data* font);
-int sk_text_size(sk_font_data* font, char* text, int* w, int* h);
-void sk_set_font_style(sk_font_data* font,int style);
-int sk_get_font_style(sk_font_data* font);
+int sk_text_line_skip(sk_font_data* font, int font_size);
+int sk_text_size(sk_font_data* font, int font_size, char* text, int* w, int* h);
+void sk_set_font_style(sk_font_data* font, int font_size, int style);
+int sk_get_font_style(sk_font_data* font, int font_size);
 void _sk_draw_bitmap_text( sk_drawing_surface * surface,
                           float x, float y,
                           const char * text,
@@ -28,6 +29,7 @@ void _sk_draw_bitmap_text( sk_drawing_surface * surface,
 void sk_draw_text(
                   sk_drawing_surface * surface,
                   sk_font_data* font,
+                  int font_size,
                   float x, float y,
                   const char * text,
                   sk_color clr);

--- a/coresdk/src/backend/text_driver.h
+++ b/coresdk/src/backend/text_driver.h
@@ -16,6 +16,7 @@ void sk_finalize_text();
 
 
 sk_font_data* sk_load_font(const char * filename, int font_size);
+void sk_add_font_size(sk_font_data *font, int font_size);
 bool sk_contains_valid_font(sk_font_data* font);
 void sk_close_font(sk_font_data* font);
 int sk_text_line_skip(sk_font_data* font, int font_size);

--- a/coresdk/src/backend/utility_functions.cpp
+++ b/coresdk/src/backend/utility_functions.cpp
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <string>
 #include <locale>
+#include <algorithm>
 
 
 using namespace std;

--- a/coresdk/src/coresdk/animations.cpp
+++ b/coresdk/src/coresdk/animations.cpp
@@ -13,6 +13,7 @@
 
 #include "utility_functions.h"
 
+#include <algorithm>
 #include <cctype>
 #include <iostream>
 #include <fstream>

--- a/coresdk/src/coresdk/text.cpp
+++ b/coresdk/src/coresdk/text.cpp
@@ -18,13 +18,9 @@
 
 static map<string, font> _fonts;
 
-bool has_font(font fnt) {
-    if (VALID_PTR(fnt, FONT_PTR))
-    {
-        return _fonts.count(fnt->name) > 0;
-    }
-
-    return false;
+bool has_font(font fnt)
+{
+    return VALID_PTR(fnt, FONT_PTR) and _fonts.count(fnt->name) > 0;
 }
 
 bool has_font(string name)
@@ -32,13 +28,8 @@ bool has_font(string name)
     return has_font(_fonts.find(name)->second);
 }
 
-bool _valid_font(font fnt, int font_size)
-{
-    return VALID_PTR(fnt, FONT_PTR) and has_font(fnt);
-}
-
 bool font_has_size(font fnt, int font_size) {
-    if (_valid_font(fnt, font_size))
+    if (has_font(fnt))
     {
         return fnt->_data.count(font_size) > 0;
     }
@@ -57,7 +48,7 @@ bool font_has_size(string name, int font_size)
 
 void font_load_size(font fnt, int font_size)
 {
-    if (_valid_font(fnt, font_size))
+    if (has_font(fnt))
     {
         sk_add_font_size(fnt, font_size);
     }

--- a/coresdk/src/coresdk/text.cpp
+++ b/coresdk/src/coresdk/text.cpp
@@ -23,6 +23,14 @@ bool has_font(string name)
     return _fonts.count(name) > 0;
 }
 
+bool font_has_size(string name, int font_size)
+{
+    bool font_exists = has_font(name);
+    bool font_size_exists = _fonts[name]->_data.count(font_size) > 0;
+
+    return font_exists and font_size_exists;
+}
+
 font font_named(string name)
 {
     if (has_font(name))

--- a/coresdk/src/coresdk/text.cpp
+++ b/coresdk/src/coresdk/text.cpp
@@ -122,6 +122,16 @@ font load_font(string name, string filename, int font_size)
     return result;
 }
 
+void font_load_size(string name, int font_size)
+{
+    if (_fonts.count(name) > 0) {
+        font fnt = _fonts[name];
+        sk_add_font_size(fnt, font_size);
+    } else {
+        raise_warning("font_load_size failed: font named \"" + name + "\" does not exist.");
+    }
+}
+
 void _print_strings(void *dest, font fnt, int font_size, string str, rectangle rc, color fg_clr, color bg_clr, font_alignment flags)
 {
     if (bg_clr.a > 0)

--- a/coresdk/src/coresdk/text.cpp
+++ b/coresdk/src/coresdk/text.cpp
@@ -25,10 +25,11 @@ bool has_font(string name)
 
 bool font_has_size(string name, int font_size)
 {
-    bool font_exists = has_font(name);
-    bool font_size_exists = _fonts[name]->_data.count(font_size) > 0;
+    if (has_font(name)) {
+        return _fonts[name]->_data.count(font_size) > 0;
+    }
 
-    return font_exists and font_size_exists;
+    return false;
 }
 
 font font_named(string name)

--- a/coresdk/src/coresdk/text.cpp
+++ b/coresdk/src/coresdk/text.cpp
@@ -89,7 +89,7 @@ font_style get_font_style(font fnt, int font_size)
     return static_cast<font_style>(sk_get_font_style(fnt, font_size));
 }
 
-font load_font(string name, string filename, int font_size)
+font load_font(string name, string filename)
 {
     if (has_font(name)) return font_named(name);
 
@@ -106,8 +106,7 @@ font load_font(string name, string filename, int font_size)
         }
     }
 
-
-    font result = sk_load_font(file_path.c_str(), font_size);
+    font result = sk_load_font(file_path.c_str(), 64);
     result->name = name; // Need to clean this up, name is set to filename in sk_load_font
     
     if (!sk_contains_valid_font(result))

--- a/coresdk/src/coresdk/text.h
+++ b/coresdk/src/coresdk/text.h
@@ -26,15 +26,26 @@ using namespace std;
 /// @class Font
 /// @constructor
 /// @csn initWithFontName:%s andSize:%s
-void set_font_style(font fnt, int font_size, font_style style);
 
-font_style get_font_style(font fnt, int font_size);
+void set_font_style(font fnt, font_style style);
+
+void set_font_style(string name, font_style style);
+
+font_style get_font_style(font fnt);
+
+font_style get_font_style(string name);
 
 font load_font(string name, string filename);
 
+void font_load_size(font fnt, int font_size);
+
 void font_load_size(string name, int font_size);
 
+bool has_font(font fnt);
+
 bool has_font(string name);
+
+bool font_has_size(font fnt, int font_size);
 
 bool font_has_size(string name, int font_size);
 
@@ -45,6 +56,5 @@ void draw_text(string text, color clr, font fnt, int font_size, float x, float y
 void draw_text(string text, color clr, font fnt, int font_size, float x, float y);
 
 void draw_text(string text, color clr, float x, float y, drawing_options opts);
-
 
 #endif /* text_hpp */

--- a/coresdk/src/coresdk/text.h
+++ b/coresdk/src/coresdk/text.h
@@ -32,6 +32,8 @@ font_style get_font_style(font fnt, int font_size);
 
 font load_font(string name, string filename, int font_size);
 
+void font_load_size(string name, int font_size);
+
 bool has_font(string name);
 
 font font_named(string name);

--- a/coresdk/src/coresdk/text.h
+++ b/coresdk/src/coresdk/text.h
@@ -30,7 +30,7 @@ void set_font_style(font fnt, int font_size, font_style style);
 
 font_style get_font_style(font fnt, int font_size);
 
-font load_font(string name, string filename, int font_size);
+font load_font(string name, string filename);
 
 void font_load_size(string name, int font_size);
 

--- a/coresdk/src/coresdk/text.h
+++ b/coresdk/src/coresdk/text.h
@@ -26,19 +26,19 @@ using namespace std;
 /// @class Font
 /// @constructor
 /// @csn initWithFontName:%s andSize:%s
-void set_font_style(font fnt, font_style style);
+void set_font_style(font fnt, int font_size, font_style style);
 
-font_style get_font_style(font fnt);
+font_style get_font_style(font fnt, int font_size);
 
-font load_font(string name, string filename, int size);
+font load_font(string name, string filename, int font_size);
 
 bool has_font(string name);
 
 font font_named(string name);
 
-void draw_text(string text, color clr, font fnt, float x, float y, drawing_options opts);
+void draw_text(string text, color clr, font fnt, int font_size, float x, float y, drawing_options opts);
 
-void draw_text(string text, color clr, font fnt, float x, float y);
+void draw_text(string text, color clr, font fnt, int font_size, float x, float y);
 
 void draw_text(string text, color clr, float x, float y, drawing_options opts);
 

--- a/coresdk/src/coresdk/text.h
+++ b/coresdk/src/coresdk/text.h
@@ -36,6 +36,8 @@ void font_load_size(string name, int font_size);
 
 bool has_font(string name);
 
+bool font_has_size(string name, int font_size);
+
 font font_named(string name);
 
 void draw_text(string text, color clr, font fnt, int font_size, float x, float y, drawing_options opts);

--- a/coresdk/src/coresdk/types.h
+++ b/coresdk/src/coresdk/types.h
@@ -63,7 +63,7 @@ enum font_alignment
 /// @class Font
 /// @pointer_wrapper
 /// @field pointer: pointer
-typedef struct _font_data *font;
+typedef struct sk_font_data *font;
 
 typedef struct _animation_script_data *animation_script;
 typedef struct _animation_data *animation;

--- a/coresdk/src/test/test_text.cpp
+++ b/coresdk/src/test/test_text.cpp
@@ -56,7 +56,7 @@ void test_font_styles()
     style = get_font_style(fnt);
     cout << "After setting the font style to ITALIC: " << stringify_font_style(style) << endl;
     
-    draw_text("Text draws in ITALICS weee!", COLOR_BLACK, fnt, 25, 0, 25);
+    draw_text("Text draws in ITALIC weee!", COLOR_BLACK, fnt, 25, 0, 25);
     set_font_style(fnt, BOLD_FONT);
     draw_text("Text draws in BOLD weee!", COLOR_BLACK, fnt, 25, 0, 50);
     set_font_style(fnt, UNDERLINE_FONT);
@@ -68,7 +68,7 @@ void test_font_auto_load()
     font fnt = font_named("leaguegothic");
 
     draw_text(
-            "Drawing text with a font size that was not explictly loaded first.",
+            "Drawing text with a font size that was not explictly loaded first. (UNDERLINE)",
             COLOR_BLACK,
             fnt,
             15,
@@ -83,12 +83,23 @@ void test_font_auto_load()
     font_load_size("leaguegothic", 50);
     cout << "Checking if size 50 exists. Should be true: " << font_has_size("leaguegothic", 50) << endl;
     draw_text(
-            "Preloaded...",
+            "Preloaded... (UNDERLINE)",
             COLOR_BLACK,
             fnt,
             50,
             0, 115
     );
+
+    set_font_style(fnt, BOLD_FONT);
+    draw_text("Test... (BOLD)", COLOR_BLACK, fnt, 35, 0, 165);
+
+    set_font_style(fnt, ITALIC_FONT);
+    draw_text("Test... (ITALIC)", COLOR_BLACK, fnt, 40, 0, 200);
+    for (int n : {0, 1, 2})
+    {
+        draw_text("Already loaded... (ITALIC)", COLOR_BLACK, fnt, 15, 0, 240 + n * 15);
+    }
+
 }
 
 void run_text_test()

--- a/coresdk/src/test/test_text.cpp
+++ b/coresdk/src/test/test_text.cpp
@@ -73,6 +73,20 @@ void test_font_auto_load()
             fnt,
             15,
             0, 100);
+
+
+    cout << "The next line should fail as the font has not been loaded." << endl;
+    cout << flush;
+    font_load_size("fail", 20);
+
+    font_load_size("leaguegothic", 50);
+    draw_text(
+            "Preloaded...",
+            COLOR_BLACK,
+            fnt,
+            50,
+            0, 115
+    );
 }
 
 void run_text_test()

--- a/coresdk/src/test/test_text.cpp
+++ b/coresdk/src/test/test_text.cpp
@@ -34,8 +34,8 @@ void test_load_font()
     cout << "Has hara.ttf (expect 0): " << has_font("hara") << endl;
     cout << "Has LeagueGothic.otf (expect 0): " << has_font("leaguegothic") << endl;
 
-    load_font("hara", "hara.ttf", 25);
-    font fnt = load_font("leaguegothic", "LeagueGothic.otf", 25);
+    load_font("hara", "hara.ttf");
+    font fnt = load_font("leaguegothic", "LeagueGothic.otf");
 
     cout << "Has hara.ttf (expect 1): " << has_font("hara") << endl;
     cout << "Has LeagueGothic.otf (expect 1): " << has_font("leaguegothic") << endl;

--- a/coresdk/src/test/test_text.cpp
+++ b/coresdk/src/test/test_text.cpp
@@ -49,17 +49,17 @@ void test_font_styles()
     
     font fnt = font_named("leaguegothic");
     
-    font_style style = get_font_style(fnt, 25);
+    font_style style = get_font_style(fnt);
     cout << "Initial font style: " << stringify_font_style(style) << endl;
     
-    set_font_style(fnt, 25, ITALIC_FONT);
-    style = get_font_style(fnt, 25);
+    set_font_style(fnt, ITALIC_FONT);
+    style = get_font_style(fnt);
     cout << "After setting the font style to ITALIC: " << stringify_font_style(style) << endl;
     
     draw_text("Text draws in ITALICS weee!", COLOR_BLACK, fnt, 25, 0, 25);
-    set_font_style(fnt, 25, BOLD_FONT);
+    set_font_style(fnt, BOLD_FONT);
     draw_text("Text draws in BOLD weee!", COLOR_BLACK, fnt, 25, 0, 50);
-    set_font_style(fnt, 25, UNDERLINE_FONT);
+    set_font_style(fnt, UNDERLINE_FONT);
     draw_text("Text draws with UNDERLINES weee!", COLOR_BLACK, fnt, 25, 0, 75);
 }
 

--- a/coresdk/src/test/test_text.cpp
+++ b/coresdk/src/test/test_text.cpp
@@ -40,7 +40,7 @@ void test_load_font()
     cout << "Has hara.ttf (expect 1): " << has_font("hara") << endl;
     cout << "Has LeagueGothic.otf (expect 1): " << has_font("leaguegothic") << endl;
 
-    draw_text("Text draws weee!", COLOR_BLACK, fnt, 0, 0);
+    draw_text("Text draws weee!", COLOR_BLACK, fnt, 25, 0, 0);
 }
 
 void test_font_styles()
@@ -49,18 +49,30 @@ void test_font_styles()
     
     font fnt = font_named("leaguegothic");
     
-    font_style style = get_font_style(fnt);
+    font_style style = get_font_style(fnt, 25);
     cout << "Initial font style: " << stringify_font_style(style) << endl;
     
-    set_font_style(fnt, ITALIC_FONT);
-    style = get_font_style(fnt);
+    set_font_style(fnt, 25, ITALIC_FONT);
+    style = get_font_style(fnt, 25);
     cout << "After setting the font style to ITALIC: " << stringify_font_style(style) << endl;
     
-    draw_text("Text draws in ITALICS weee!", COLOR_BLACK, fnt, 0, 25);
-    set_font_style(fnt, BOLD_FONT);
-    draw_text("Text draws in BOLD weee!", COLOR_BLACK, fnt, 0, 50);
-    set_font_style(fnt, UNDERLINE_FONT);
-    draw_text("Text draws with UNDERLINES weee!", COLOR_BLACK, fnt, 0, 75);
+    draw_text("Text draws in ITALICS weee!", COLOR_BLACK, fnt, 25, 0, 25);
+    set_font_style(fnt, 25, BOLD_FONT);
+    draw_text("Text draws in BOLD weee!", COLOR_BLACK, fnt, 25, 0, 50);
+    set_font_style(fnt, 25, UNDERLINE_FONT);
+    draw_text("Text draws with UNDERLINES weee!", COLOR_BLACK, fnt, 25, 0, 75);
+}
+
+void test_font_auto_load()
+{
+    font fnt = font_named("leaguegothic");
+
+    draw_text(
+            "Drawing text with a font size that was not explictly loaded first.",
+            COLOR_BLACK,
+            fnt,
+            15,
+            0, 100);
 }
 
 void run_text_test()
@@ -70,7 +82,8 @@ void run_text_test()
     cout << "Testing text API" << endl;
     test_load_font();
     test_font_styles();
-    
+    test_font_auto_load();
+
     refresh_screen();
     delay(3000);
 

--- a/coresdk/src/test/test_text.cpp
+++ b/coresdk/src/test/test_text.cpp
@@ -79,7 +79,9 @@ void test_font_auto_load()
     cout << flush;
     font_load_size("fail", 20);
 
+    cout << "Checking is size 50 exists. Should be false: " << font_has_size("leaguegothic", 50) << endl;
     font_load_size("leaguegothic", 50);
+    cout << "Checking if size 50 exists. Should be true: " << font_has_size("leaguegothic", 50) << endl;
     draw_text(
             "Preloaded...",
             COLOR_BLACK,

--- a/coresdk/src/test/test_windows.cpp
+++ b/coresdk/src/test/test_windows.cpp
@@ -44,7 +44,7 @@ void run_windows_tests()
         draw_bitmap(light, 10, 100);
         draw_bitmap("light", 75, 100);
         
-        draw_text("Hello World", COLOR_BLUE, fnt, 200, 100);
+        draw_text("Hello World", COLOR_BLUE, fnt, 64, 200, 100);
         
         refresh_screen();
     }

--- a/coresdk/src/test/test_windows.cpp
+++ b/coresdk/src/test/test_windows.cpp
@@ -23,7 +23,7 @@ void run_windows_tests()
 {
     open_window("Hello World", 800, 600);
     
-    font fnt = load_font("hara", "hara.ttf", 64);
+    font fnt = load_font("hara", "hara.ttf");
     bitmap light = load_bitmap("light", "on_med.png");
     
 //    http_response response = http_get("http://www.swinburne.edu.au/cwis/php_pages/webapps/marketing/promotiles-v3/assets/img/RgakQ.jpg", 80);

--- a/projects/bash/build-linux.sh
+++ b/projects/bash/build-linux.sh
@@ -29,7 +29,7 @@ function run_test_program {
 
 function build_shared_library {
     echo "Creating shared library"
-    g++ -shared -std=c++1y -o ./out/linux/libsplashkit.so -I${CORE_SDK_PATH}/src/coresdk/ -I${CORE_SDK_PATH}/src/backend/ ${CORE_SDK_PATH}/src/coresdk/*.cpp ${CORE_SDK_PATH}/src/backend/*.cpp ${ALL_SDL2_LIBS} ${OTHER_LIB} -fPIC
+    g++ -shared -g -std=c++1y -o ./out/linux/libsplashkit.so -I${CORE_SDK_PATH}/src/coresdk/ -I${CORE_SDK_PATH}/src/backend/ ${CORE_SDK_PATH}/src/coresdk/*.cpp ${CORE_SDK_PATH}/src/backend/*.cpp ${ALL_SDL2_LIBS} ${OTHER_LIB} -fPIC
 
 
     echo "Fails without root: Installing library manually into /usr/lib"


### PR DESCRIPTION
* ```load_font``` will currently provide a default size of 64.
* Calls to draw_text will load the font automatically for a given size if it has not already loaded.
* Fonts can be loaded early if desired by calling ```font_load_size```.
* ```font_has_size``` returns true if the font has been loaded with a given size.