### PR TITLE
NEW: Added to quad_geometry, 

### DIFF
--- a/coresdk/src/coresdk/matrix_2d.cpp
+++ b/coresdk/src/coresdk/matrix_2d.cpp
@@ -47,3 +47,52 @@ string matrix_to_string(const matrix_2d &matrix)
     result << " ------------------------------";
     return result.str();
 }
+
+
+matrix_2d matrix_multiply(const matrix_2d &m1,const matrix_2d &m2)
+{
+    
+    matrix_2d result;
+    result.elements[0][0] = m1.elements[0][0] * m2.elements[0][0] +
+                            m1.elements[0][1] * m2.elements[1][0] +
+                            m1.elements[0][2] * m2.elements[2][0];
+    
+    result.elements[0][1] = m1.elements[0][0] * m2.elements[0][1] +
+                            m1.elements[0][1] * m2.elements[1][1] +
+                            m1.elements[0][2] * m2.elements[2][1];
+    
+    result.elements[0][2] = m1.elements[0][0] * m2.elements[0][2] +
+                            m1.elements[0][1] * m2.elements[1][2] +
+                            m1.elements[0][2] * m2.elements[2][2];
+    
+    result.elements[1][0] = m1.elements[1][0] * m2.elements[0][0] +
+                            m1.elements[1][1] * m2.elements[1][0] +
+                            m1.elements[1][2] * m2.elements[2][0];
+    
+    result.elements[1][1] = m1.elements[1][0] * m2.elements[0][1] +
+                            m1.elements[1][1] * m2.elements[1][1] +
+                            m1.elements[1][2] * m2.elements[2][1];
+    
+    result.elements[1][2] = m1.elements[1][0] * m2.elements[0][2] +
+                            m1.elements[1][1] * m2.elements[1][2] +
+                            m1.elements[1][2] * m2.elements[2][2];
+    
+    result.elements[2][0] = m1.elements[2][0] * m2.elements[0][0] +
+                            m1.elements[2][1] * m2.elements[1][0] +
+                            m1.elements[2][2] * m2.elements[2][0];
+   
+    result.elements[2][1] = m1.elements[2][0] * m2.elements[0][1] +
+                            m1.elements[2][1] * m2.elements[1][1] +
+                            m1.elements[2][2] * m2.elements[2][1];
+    
+    result.elements[2][2] = m1.elements[2][0] * m2.elements[0][2] +
+                            m1.elements[2][1] * m2.elements[1][2] +
+                            m1.elements[2][2] * m2.elements[2][2];
+    
+
+
+    return result;
+}
+
+
+

--- a/coresdk/src/coresdk/matrix_2d.cpp
+++ b/coresdk/src/coresdk/matrix_2d.cpp
@@ -93,6 +93,21 @@ matrix_2d matrix_multiply(const matrix_2d &m1,const matrix_2d &m2)
 
     return result;
 }
+point_2d matrix_multiply(const matrix_2d &m, const point_2d &pts)
+{
+    point_2d result;
+    result.x = pts.x * m.elements[0][0]  +  pts.y * m.elements[0][1] + m.elements[0][2];
+    result.y = pts.x * m.elements[1][0]  +  pts.y * m.elements[1][1] + m.elements[1][2];
+    
+    return result;
+}
 
+void apply_matrix(const matrix_2d &m, quad &q)
+{
+    for(int i = 0; i < 4; i++)
+    {
+        q.points[i] = matrix_multiply(m, q.points[i]);
+    }
+}
 
 

--- a/coresdk/src/coresdk/matrix_2d.h
+++ b/coresdk/src/coresdk/matrix_2d.h
@@ -186,10 +186,20 @@ matrix_2d scale_rotate_translate_matrix(const point_2d &scale, float deg, const 
 string matrix_to_string(const matrix_2d &matrix);
 
 /**
- * 
+ *  Multiply matrix_2d by another matrix_2d and return a matrix result as a new matrix_2d,
  */
 matrix_2d matrix_multiply(const matrix_2d  &m1,const matrix_2d &m2);
 
+/**
+ * Use a matrix to transform all of the points in a quad.
+ */
+void apply_matrix(const matrix_2d m, quad _quad);
+
+/**
+ *  Multiplying matrix by point_2d and returning as point_2d.
+ */
+
+point_2d matrix_multiply(const matrix_2d &m, const point_2d &pts);
 
 
 

--- a/coresdk/src/coresdk/matrix_2d.h
+++ b/coresdk/src/coresdk/matrix_2d.h
@@ -185,4 +185,12 @@ matrix_2d scale_rotate_translate_matrix(const point_2d &scale, float deg, const 
 /// @csn description
 string matrix_to_string(const matrix_2d &matrix);
 
+/**
+ * 
+ */
+matrix_2d matrix_multiply(const matrix_2d  &m1,const matrix_2d &m2);
+
+
+
+
 #endif /* matrix_2d_h */

--- a/coresdk/src/coresdk/quad_geometry.cpp
+++ b/coresdk/src/coresdk/quad_geometry.cpp
@@ -8,9 +8,10 @@
 
 #include "quad_geometry.h"
 #include "types.h"
+#include "rectangle_geometry.h"
 
 
-
+ 
 quad quad_from(float x_top_left,float y_top_left,float x_top_right,float y_top_right, float x_bottom_left,float y_bottom_left,float x_bottom_right,float y_bottom_right)
 {
     quad result;
@@ -24,3 +25,18 @@ quad quad_from(float x_top_left,float y_top_left,float x_top_right,float y_top_r
     result.points[3].y = y_bottom_right;
     return result;
 }
+
+
+
+quad quad_from(const rectangle &rect)
+{
+    quad result;
+    result = quad_from(
+                       rectangle_left(rect), rectangle_top(rect),
+                       rectangle_right(rect), rectangle_top(rect),
+                       rectangle_left(rect), rectangle_bottom(rect),
+                       rectangle_right(rect), rectangle_bottom(rect) );
+    return result;
+}
+
+

--- a/coresdk/src/coresdk/quad_geometry.cpp
+++ b/coresdk/src/coresdk/quad_geometry.cpp
@@ -40,21 +40,6 @@ quad quad_from(const rectangle &rect)
     return result;
 }
 
-point_2d matrix_multiply(const matrix_2d &m, const point_2d &pts)
-{
-    point_2d result;
-    result.x = pts.x * m.elements[0][0]  +  pts.y * m.elements[0][1] + m.elements[0][2];
-    result.y = pts.x * m.elements[1][0]  +  pts.y * m.elements[1][1] + m.elements[1][2];
-    
-    return result;
-}
 
-void apply_matrix(const matrix_2d &m, quad &q)
-{
-    for(int i = 0; i < 4; i++)
-    {
-        q.points[i] = matrix_multiply(m, q.points[i]);
-    }
-}
 
 

--- a/coresdk/src/coresdk/quad_geometry.cpp
+++ b/coresdk/src/coresdk/quad_geometry.cpp
@@ -9,7 +9,8 @@
 #include "quad_geometry.h"
 #include "types.h"
 #include "rectangle_geometry.h"
-
+#include "matrix_2d.h"
+#include "vector_2d.h"
 
  
 quad quad_from(float x_top_left,float y_top_left,float x_top_right,float y_top_right, float x_bottom_left,float y_bottom_left,float x_bottom_right,float y_bottom_right)
@@ -37,6 +38,23 @@ quad quad_from(const rectangle &rect)
                        rectangle_left(rect), rectangle_bottom(rect),
                        rectangle_right(rect), rectangle_bottom(rect) );
     return result;
+}
+
+point_2d matrix_multiply(const matrix_2d &m, const point_2d &pts)
+{
+    point_2d result;
+    result.x = pts.x * m.elements[0][0]  +  pts.y * m.elements[0][1] + m.elements[0][2];
+    result.y = pts.x * m.elements[1][0]  +  pts.y * m.elements[1][1] + m.elements[1][2];
+    
+    return result;
+}
+
+void apply_matrix(const matrix_2d &m, quad &q)
+{
+    for(int i = 0; i < 4; i++)
+    {
+        q.points[i] = matrix_multiply(m, q.points[i]);
+    }
 }
 
 

--- a/coresdk/src/coresdk/quad_geometry.h
+++ b/coresdk/src/coresdk/quad_geometry.h
@@ -10,17 +10,29 @@
 #define quad_geometry_h
 
 #include "types.h"
+#include "matrix_2d.h"
+
 
 /**
  *Returns a quad for the passed in x & y points.
  */
 quad quad_from(float x_top_left, float y_top_left, float x_top_right, float y_top_right, float x_bottom_left, float y_bottom_left, float x_bottom_right, float y_bottom_right );
 
-
 /**
- * Returns a quad from x-y of given recatangle
+ * Returns a quad from the x-y points of a given recatangle
  */
 quad quad_from(const rectangle &rect);
+
+/**
+ * Use a matrix to transform all of the points in a quad.
+ */
+void apply_matrix(const matrix_2d m, quad _quad);
+
+/**
+ *  Multiplying matrix by point_2d and returning as point_2d.
+ */
+
+point_2d matrix_multiply(const matrix_2d &m, const point_2d &pts);
 
 
 #endif /* quad_geometry_h */

--- a/coresdk/src/coresdk/quad_geometry.h
+++ b/coresdk/src/coresdk/quad_geometry.h
@@ -23,16 +23,6 @@ quad quad_from(float x_top_left, float y_top_left, float x_top_right, float y_to
  */
 quad quad_from(const rectangle &rect);
 
-/**
- * Use a matrix to transform all of the points in a quad.
- */
-void apply_matrix(const matrix_2d m, quad _quad);
-
-/**
- *  Multiplying matrix by point_2d and returning as point_2d.
- */
-
-point_2d matrix_multiply(const matrix_2d &m, const point_2d &pts);
 
 
 #endif /* quad_geometry_h */

--- a/coresdk/src/coresdk/quad_geometry.h
+++ b/coresdk/src/coresdk/quad_geometry.h
@@ -11,7 +11,16 @@
 
 #include "types.h"
 
-
+/**
+ *Returns a quad for the passed in x & y points.
+ */
 quad quad_from(float x_top_left, float y_top_left, float x_top_right, float y_top_right, float x_bottom_left, float y_bottom_left, float x_bottom_right, float y_bottom_right );
+
+
+/**
+ * Returns a quad from x-y of given recatangle
+ */
+quad quad_from(const rectangle &rect);
+
 
 #endif /* quad_geometry_h */

--- a/coresdk/src/coresdk/vector_2d.cpp
+++ b/coresdk/src/coresdk/vector_2d.cpp
@@ -539,3 +539,14 @@ vector_2d vector_out_of_rect_from_circle(const circle &c, const rectangle &rect,
     int max_idx;
     return vector_over_lines_from_circle(c, lines_from(rect), velocity, max_idx);
 }
+
+vector_2d matrix_multiply(const matrix_2d &m, const vector_2d &v)
+{
+    
+    vector_2d result;
+    result.x = v.x * m.elements[0][0]  +  v.y * m.elements[0][1] + m.elements[0][2];
+    result.y = v.x * m.elements[1][0]  +  v.y * m.elements[1][1] + m.elements[1][2];
+    
+
+    return result;
+}

--- a/coresdk/src/coresdk/vector_2d.h
+++ b/coresdk/src/coresdk/vector_2d.h
@@ -10,6 +10,7 @@
 #define vector_2d_h
 
 #include "types.h"
+#include "matrix_2d.h"
 
 #include <string>
 using namespace std;
@@ -159,4 +160,12 @@ vector_2d vector_out_of_circle_from_circle(const circle &src, const circle &boun
  */
 vector_2d vector_out_of_rect_from_circle(const circle &c, const rectangle &rect, const vector_2d &velocity);
 
+/**
+ *  Multiply a matrix by a vector.  return as vector
+ */
+vector_2d matrix_multiply(const matrix_2d &m, const vector_2d &v);
+
+
 #endif /* vector_2d_h */
+
+


### PR DESCRIPTION
Ported across  apply_matrix, matrix_multiply (overloads: vector_2d, matrix_2d and point_2d), quad_from also edited..



files effected : 	
        modified:   coresdk/src/coresdk/matrix_2d.cpp
	modified:   coresdk/src/coresdk/matrix_2d.h
	modified:   coresdk/src/coresdk/quad_geometry.cpp
	modified:   coresdk/src/coresdk/quad_geometry.h
	modified:   coresdk/src/coresdk/vector_2d.cpp
	modified:   coresdk/src/coresdk/vector_2d.h