### PR TITLE
FIX: Include math functions for rounding

### DIFF
--- a/coresdk/src/coresdk/images.cpp
+++ b/coresdk/src/coresdk/images.cpp
@@ -17,7 +17,7 @@
 
 #include <map>
 #include <cstdlib>
-#include <math.h>
+#include <cmath>
 
 using namespace std;
 

--- a/coresdk/src/coresdk/images.cpp
+++ b/coresdk/src/coresdk/images.cpp
@@ -17,6 +17,7 @@
 
 #include <map>
 #include <cstdlib>
+#include <math.h>
 
 using namespace std;
 


### PR DESCRIPTION
FIX: images.cpp requires the round function but didn't include the math
header, this fixes that