### PR TITLE
Update cmake to compile libraries and test binary to root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-
-# Created by https://www.gitignore.io/api/osx,xcode
-
 ### OSX ###
 *.DS_Store
 .AppleDouble
@@ -31,16 +28,12 @@ Temporary Items
 
 
 ### Xcode ###
-# Xcode
-#
-# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
-## Build generated
+# Build generated
 build/
 DerivedData/
-test_database
 
-## Various settings
+# Various settings
 *.pbxuser
 !default.pbxuser
 *.mode1v3
@@ -51,22 +44,10 @@ test_database
 !default.perspectivev3
 xcuserdata/
 
-## Other
+# Other
 *.moved-aside
 *.xccheckout
 *.xcscmblueprint
-
-## Original
-projects/Xcode/DerivedData/
-coresdk/external/SDL
-coresdk/external/SDL_gfx
-coresdk/external/SDL_image
-coresdk/external/SDL_mixer
-coresdk/external/SDL_net
-coresdk/external/SDL_ttf
-coresdk/external/setup.log
-coresdk/include
-projects/bash/out
 
 ### CLion JetBrains IDE ###
 .idea
@@ -82,14 +63,10 @@ swap
 # auto-generated tag files
 tags
 
-# CMake
-CMakeCache.txt
-CMakeFiles/
-Makefile
-cmake_install.cmake
-libsplashkit.a
-splashkit_test
-projects/cmake/Resources
+### CMake ###
+projects/cmake/
+!CMakeLists.txt
 
-# Splashkit
-libsplashkit.so
+### Generated Folders ###
+bin/
+out/

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,13 @@ tags
 ### CMake ###
 projects/cmake/
 !CMakeLists.txt
+CMakeCache.txt
+CMakeFiles/
+Makefile
+cmake_install.cmake
+libsplashkit.a
+splashkit_test
+projects/cmake/Resources
 
 ### Generated Folders ###
 bin/

--- a/projects/bash/build-win32.sh
+++ b/projects/bash/build-win32.sh
@@ -2,8 +2,8 @@
 
 echo "Ensure you run this from the mingw 32 shell of Msys2"
 
-rm -rf ./out/win32
-mkdir -p ./out/win32
+rm -rf ../../out/win32
+mkdir -p ../../out/win32
 
 CORE_SDK_PATH="../../coresdk"
 

--- a/projects/bash/build-win64.sh
+++ b/projects/bash/build-win64.sh
@@ -2,8 +2,8 @@
 
 echo "Ensure you run this from the mingw 64 shell of Msys2"
 
-rm -rf ./out/win64
-mkdir -p ./out/win64
+rm -rf ../../out/win32
+mkdir -p ../../out/win32
 
 CORE_SDK_PATH="../../coresdk"
 

--- a/projects/cmake/CMakeLists.txt
+++ b/projects/cmake/CMakeLists.txt
@@ -1,69 +1,170 @@
 cmake_minimum_required(VERSION 3.2)
 project(splashkit)
 
+# SK Directories relative to cmake project
+set(SK_SRC "../../coresdk/src")
+set(SK_EXT "../../coresdk/external")
+set(SK_LIB "../../coresdk/lib")
+set(SK_OUT "../../out")
+set(SK_BIN "../../bin")
+
+#### SETUP ####
 if (APPLE)
-    set(LIB_FLAGS "-L../../coresdk/lib/mac -framework IOKit -framework ForceFeedback -framework CoreFoundation -framework Cocoa -framework Carbon -framework AudioUnit -framework AudioToolbox -framework CoreAudio -framework CoreVideo -lSDL2 -lSDL2_mixer -lSDL2_ttf -lSDL2_gfx -lSDL2_image -lSDL2_net -lpthread -lbz2 -lFLAC -lvorbis -lz -lpng16 -lvorbisfile -lmikmod -logg -lwebp -lsmpeg2 -lfreetype -lcurl -lsqlite3 -ldl")
+    # MAC OS PROJECT FLAGS
+    set(LIB_FLAGS "-L../../coresdk/lib/mac \
+                   -framework IOKit \
+                   -framework ForceFeedback \
+                   -framework CoreFoundation \
+                   -framework Cocoa \
+                   -framework Carbon \
+                   -framework AudioUnit \
+                   -framework AudioToolbox \
+                   -framework CoreAudio \
+                   -framework CoreVideo \
+                   -lSDL2 \
+                   -lSDL2_mixer \
+                   -lSDL2_ttf \
+                   -lSDL2_gfx \
+                   -lSDL2_image \
+                   -lSDL2_net \
+                   -lpthread \
+                   -lbz2 \
+                   -lFLAC \
+                   -lvorbis \
+                   -lz \
+                   -lpng16 \
+                   -lvorbisfile \
+                   -lmikmod \
+                   -logg \
+                   -lwebp \
+                   -lsmpeg2 \
+                   -lfreetype \
+                   -lcurl \
+                   -lsqlite3 \
+                   -ldl")
+# WINDOWS PROJECT FLAGS
 elseif(MSYS)
-    set(LIB_FLAGS "-L../../coresdk/lib/win64 -L/mingw64/lib -L/usr/lib -lSDL2main")
+    set(LIB_FLAGS "-L../../coresdk/lib/win64 \
+                   -L/mingw64/lib \
+                   -L/usr/lib \
+                   -lSDL2main")
+# LINUX PROJECT FLAGS
 else()
-    set(LIB_FLAGS "-lSDL2 -lSDL2_mixer -lSDL2_ttf -lSDL2_gfx -lSDL2_image -lSDL2_net -lpthread -lbz2 -lFLAC -lvorbis -lz -lpng16 -lvorbisfile -lmikmod -logg -lwebp -lsmpeg2 -lfreetype -lcurl -lsqlite3 -ldl")
+    set(LIB_FLAGS "-lSDL2 \
+                   -lSDL2_mixer \
+                   -lSDL2_ttf \
+                   -lSDL2_gfx \
+                   -lSDL2_image \
+                   -lSDL2_net \
+                   -lpthread \
+                   -lbz2 \
+                   -lFLAC \
+                   -lvorbis \
+                   -lz \
+                   -lpng16 \
+                   -lvorbisfile \
+                   -lmikmod \
+                   -logg \
+                   -lwebp \
+                   -lsmpeg2 \
+                   -lfreetype \
+                   -lcurl \
+                   -lsqlite3 \
+                   -ldl")
 endif()
 
+# FLAGS
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 
+# SOURCE FILES
 file(GLOB SOURCE_FILES
-        ../../coresdk/src/coresdk/*.cpp
-        ../../coresdk/src/backend/*.cpp
-        ../../coresdk/external/civetweb/src/civetweb.cpp)
+    "${SK_SRC}/coresdk/*.cpp"
+    "${SK_SRC}/backend/*.cpp"
+    "${SK_EXT}/civetweb/src/civetweb.cpp"
+)
 
+# TEST FILE INCLUDES
 file(GLOB TEST_SOURCE_FILES
-        ../../coresdk/src/test/*.cpp
-        )
+    "${SK_SRC}/test/*.cpp"
+)
 
+# SKSDK FILE INCLUDES
 file(GLOB INCLUDE_FILES
-        ../../coresdk/src/coresdk/*.h
-        )
+    "${SK_SRC}/coresdk/*.h"
+)
 
-include_directories(../../coresdk/src)
-include_directories(../../coresdk/src/coresdk)
-include_directories(../../coresdk/src/backend)
-include_directories(../../coresdk/src/test)
-include_directories(../../coresdk/external/civetweb/include)
+# DIRECTORY INCLUDES
+include_directories("${SK_SRC}")
+include_directories("${SK_SRC}/coresdk")
+include_directories("${SK_SRC}/backend")
+include_directories("${SK_SRC}/test")
+include_directories("${SK_EXT}/civetweb/include")
 
+# MAC OS AND WINDOWS DIRECTORY INCLUDES
 if (APPLE OR MSYS)
-    include_directories(../../coresdk/external/SDL/include)
-    include_directories(../../coresdk/external/SDL_gfx)
-    include_directories(../../coresdk/external/SDL_image)
-    include_directories(../../coresdk/external/SDL_mixer)
-    include_directories(../../coresdk/external/SDL_net)
-    include_directories(../../coresdk/external/SDL_ttf)
+    include_directories("${SK_EXT}/SDL/include")
+    include_directories("${SK_EXT}/SDL_gfx")
+    include_directories("${SK_EXT}/SDL_image")
+    include_directories("${SK_EXT}/SDL_mixer")
+    include_directories("${SK_EXT}/SDL_net")
+    include_directories("${SK_EXT}/SDL_ttf")
 endif()
-
+# MAC OS ONLY DIRECTORY INCLUDES
 if (APPLE)
-    include_directories(../../coresdk/external/SDL_image/external/libpng-1.6.2)
+    include_directories("${SK_EXT}/SDL_image/external/libpng-1.6.2")
 endif()
-
+# WINDOWS ONLY DIRECTORY INCLUDES
 if (MSYS)
     include_directories(/mingw64/include)
     include_directories(/mingw64/include/libpng16)
-    include_directories(../../coresdk/lib/win_inc)
-    include_directories(../../coresdk/external/sqlite)
+    include_directories("${SK_LIB}/win_inc")
+    include_directories("${SK_EXT}/sqlite")
 endif()
 
+#### END SETUP ####
+#### SplashKit STATIC LIBRARY ####
+add_library(SplashKit STATIC ${SOURCE_FILES} ${INCLUDE_FILES})
 
-add_library(splashkit SHARED ${SOURCE_FILES} ${INCLUDE_FILES})
+target_link_libraries(SplashKit ${LIB_FLAGS})
+
 if (MSYS)
-    target_link_libraries(splashkit SDL2_mixer.dll SDL2_image.dll SDL2_net.dll  libcivetweb.dll SDL2.dll SDL2_ttf.dll SDL2_ttf.dll libcurl.dll libSDL2_gfx-1-0-0.dll libpng16-16.dll libsqlite.dll)
+    target_link_libraries(SplashKit SDL2_mixer.dll
+                                    SDL2_image.dll
+                                    SDL2_net.dll
+                                    libcivetweb.dll
+                                    SDL2.dll
+                                    SDL2_ttf.dll
+                                    SDL2_ttf.dll
+                                    libcurl.dll
+                                    libSDL2_gfx-1-0-0.dll
+                                    libpng16-16.dll
+                                    libsqlite.dll)
 endif()
-target_link_libraries(splashkit ${LIB_FLAGS})
 
-add_executable(splashkit_test ${TEST_SOURCE_FILES})
-target_link_libraries(splashkit_test splashkit)
-target_link_libraries(splashkit_test ${LIB_FLAGS})
+# SET OUTPUT TO /path/to/splashkit/out/lib
+set_target_properties(SplashKit
+    PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY "${SK_OUT}/lib"
+)
 
-add_custom_command(TARGET splashkit_test PRE_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ../../coresdk/src/test/Resources $<TARGET_FILE_DIR:splashkit_test>/Resources)
+#### END SplashKit STATIC LIBRARY ####
+#### sktest EXECUTABLE ####
+add_executable(sktest ${TEST_SOURCE_FILES})
 
-install(TARGETS splashkit DESTINATION lib)
-install(FILES ${INCLUDE_FILES} DESTINATION include/splashkit)
+target_link_libraries(sktest SplashKit)
+target_link_libraries(sktest ${LIB_FLAGS})
+
+set_target_properties(sktest
+    PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${SK_BIN}
+)
+
+# Copy resources folder in
+add_custom_command(TARGET sktest
+    PRE_BUILD COMMAND
+    ${CMAKE_COMMAND} -E copy_directory "${SK_SRC}/test/Resources" $<TARGET_FILE_DIR:sktest>/Resources)
+
+#### END sktest EXECUTABLE ####
+
+install(TARGETS SplashKit DESTINATION lib)
+install(FILES ${INCLUDE_FILES} DESTINATION include/SplashKit)


### PR DESCRIPTION
This PR is needed for the SK translator to have a consistent `out` directory to refer to when generating translated files, libraries etc.

- Static libraries generated will be placed in `/out/lib` for the translator to look at when creating the C dylib.
- Test binaries compiles to `/bin/sktest`
- Variablises directories so that changes to the directory structure can be changed easily (i.e., if we remove the root `coresdk` and placing its content in root).

I've asked @jarmstrong to have a look through just to make sure nothing is severely broken with the build script/CI after the commit.