### PR TITLE
Add missing function pointers to sprite header

### DIFF
--- a/coresdk/src/coresdk/sprites.cpp
+++ b/coresdk/src/coresdk/sprites.cpp
@@ -1402,12 +1402,12 @@ void update_all_sprites(float pct)
     call_for_all_sprites(&_update_sprite_pct, pct);
 }
 
-void call_for_all_sprites(sprite_function fn)
+void call_for_all_sprites(sprite_function *fn)
 {
     _call_for_all_sprites(current_pack(), fn);
 }
 
-void call_for_all_sprites(sprite_float_function fn, float val)
+void call_for_all_sprites(sprite_float_function *fn, float val)
 {
     _call_for_all_sprites(current_pack(), fn, val);
 }
@@ -1497,7 +1497,7 @@ bool sprite_on_screen_at(sprite s, const point_2d &pt)
 
 bool sprite_at(sprite s, const point_2d &pt)
 {
-	return sprite_point_collision(s, pt);
+    return sprite_point_collision(s, pt);
 }
 
 rectangle sprite_collision_rectangle(sprite s)

--- a/coresdk/src/coresdk/sprites.h
+++ b/coresdk/src/coresdk/sprites.h
@@ -75,7 +75,7 @@ typedef void (sprite_event_handler) (sprite s, sprite_event_kind evt);
 typedef void (sprite_function)(sprite s);
 
 /**
- *  The sprite single function is used with sprite packs to provide a 
+ *  The sprite single function is used with sprite packs to provide a
  *  procedure to be called for each of the Sprites in the sprite pack,
  *  where a float value is required.
  *
@@ -1783,14 +1783,14 @@ void update_all_sprites(float pct);
  *
  * @param fn The sprite function to call on all sprites.
  */
-void call_for_all_sprites(sprite_function fn);
+void call_for_all_sprites(sprite_function *fn);
 
 /**
  * Call the supplied function for all sprites in the current pack.
  *
  * @param fn The sprite function to call on all sprites.
  */
-void call_for_all_sprites(sprite_float_function fn, float val);
+void call_for_all_sprites(sprite_float_function *fn, float val);
 
 /**
  * Create a new sprite_pack with a given name. This pack can then be


### PR DESCRIPTION
Sprite header and implementation were missing the function pointer asterisk, causing compilation errors on translated C code.