### PR TITLE
Fix parser violations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,13 +64,12 @@ swap
 tags
 
 ### CMake ###
-projects/cmake/*
-!CMakeLists.txt
 CMakeCache.txt
 CMakeFiles/
 Makefile
 cmake_install.cmake
 libsplashkit.a
+libsplashkit.ao
 splashkit_test
 projects/cmake/Resources
 

--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,8 @@ swap
 tags
 
 ### CMake ###
-projects/cmake/
+projects/cmake/*
+!CMakeLists.txt
 CMakeCache.txt
 CMakeFiles/
 Makefile

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,0 +1,25 @@
+CommitMsg:
+  ALL:
+    on_warn: fail
+  EmptyMessage:
+    enabled: true
+  MessageFormat:
+    enabled: true
+    pattern: '((NEW|FIX|ENHANCE|LOOKS|SPEED|QUALITY|DOC|CONFIG|TEST): [A-Z].+)|(Merge .+)'
+    expected_pattern_message: '<NEW|FIX|ENHANCE|LOOKS|SPEED|QUALITY|DOC|CONFIG|TEST>: <Message Subject>'
+    sample_message: 'CONFIG: Add overcommit to project'
+  TraillingPeriod:
+    enabled: true
+  TextWidth:
+    enabled: true
+PreCommit:
+  AuthorEmail:
+    enabled: true
+    on_warn: fail
+  AuthorName:
+    enabled: true
+    on_warn: fail
+  HardTabs:
+    enabled: true
+  TrailingWhitespace:
+    enabled: true

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# splashkit
+# SplashKit
 
 [![Build Status (Linux / OSX)](https://travis-ci.org/splashkit/splashkit.svg?branch=develop)](https://travis-ci.org/splashkit/splashkit)
 [![Build status](https://ci.appveyor.com/api/projects/status/rp46q64glrttols6/branch/develop?svg=true)](https://ci.appveyor.com/project/macite/splashkit/branch/develop)
 
 Get involved:
 
-`git clone --recursive -j2 https://github.com/splashkit/splashkit.git`
+```
+$ git clone --recursive -j2 https://github.com/splashkit/splashkit.git
+```
+
+Refer to documentation guidelines [here](https://github.com/splashkit/splashkit-translator#splashkit-documentation-guidelines).

--- a/coresdk/src/coresdk/animations.h
+++ b/coresdk/src/coresdk/animations.h
@@ -1,7 +1,11 @@
 /**
  * @header Animations
  * @author Andrew Cain
- * @brief Animations in SplashKit can be used to move between cells in bitmaps and sprites. Each Animation generates a number sequence that can then be used when drawing bitmaps.
+ * @brief Animations in SplashKit can be used to move between cells in
+ *        bitmaps and sprites. Each animation generates a number sequence
+ *        that can then be used when drawing bitmaps.
+ *
+ * @attribute static animation
  */
 
 #ifndef animations_h
@@ -23,6 +27,7 @@ using namespace std;
  *
  * @returns Returns the newly loaded `animation_script`.
  *
+ * @attribute class animation_script
  * @attribute constructor true
  */
 animation_script load_animation_script(string name, string filename);
@@ -109,7 +114,7 @@ bool has_animation_named(animation_script script, string name);
  *
  * @returns Returns an `int` equal to the total number of animations in the script.
  *
- * @attribute class     animation
+ * @attribute class     animation_script
  * @attribute getter    animation_count
  * @attribute self      script
  */
@@ -199,10 +204,10 @@ animation create_animation(string script_name, int idx);
  *
  * @param ani           The `animation` to be disposed of.
  *
- * @attribute class     animation
- * @attribute method    free
- * @attribute destructor true
- * @attribute self      ani
+ * @attribute class       animation
+ * @attribute destructor  true
+ * @attribute method      free
+ * @attribute self        ani
  */
 void free_animation(animation ani);
 
@@ -316,7 +321,7 @@ int animation_index(animation_script script, string name);
  *
  * @attribute class     animation
  * @attribute getter    name
- * @attribute self a    nimation
+ * @attribute self      temp
  *
  * @returns Returns the name of the `animation` in the `animation_script`.
  */

--- a/coresdk/src/coresdk/sprites.h
+++ b/coresdk/src/coresdk/sprites.h
@@ -1789,6 +1789,8 @@ void call_for_all_sprites(sprite_function *fn);
  * Call the supplied function for all sprites in the current pack.
  *
  * @param fn The sprite function to call on all sprites.
+ * @attribute class
+ * @attribute static
  */
 void call_for_all_sprites(sprite_float_function *fn, float val);
 

--- a/coresdk/src/coresdk/web_server.h
+++ b/coresdk/src/coresdk/web_server.h
@@ -2,6 +2,8 @@
  * @header Web Server
  * @author James Armstrong
  * @brief
+ *
+ * @attribute static web_server
  */
 
 #ifndef web_server_h_
@@ -31,87 +33,88 @@ typedef struct sk_server_response *server_response;
 /**
  * Starts the web server on a given port number.
  *
- * @param port          The port number to connect through.
+ * @param port  The port number to connect through.
  *
- * @attribute           constructor true
+ * @returns     Returns a new `web_server` instance.
  *
- * @returns             Returns a new `web_server` instance.
+ * @attribute constructor true
+ * @attribute class       web_server
  */
 web_server start_web_server(string port);
 
 /**
  * Creates a new web server instance and starts it.
  *
- * @attribute           constructor true
- * @attribute           class web_server
- * @attribute           method start
+ * @attribute constructor true
+ * @attribute class       web_server
+ * @attribute method      start
  *
- * @returns             Returns a new `web_sever` instance.
+ * @returns Returns a new `web_sever` instance.
  */
 web_server start_web_server();
 
 /**
  * Returns true if the given `web_sever` has pending requests.
  *
- * @param server        The `web_server` to check for waiting requests.
- *
- * @attribute           class web_server
- * @attribute           self server
+ * @param server  The `web_server` to check for waiting requests.
  *
  * @returns Returns a `bool` denoting whether the `web_server` has pending requests.
+ *
+ * @attribute self  server
+ * @attribute class web_server
  */
 bool has_waiting_requests(web_server server);
 
 /**
  * Stops a given `web_server` instance.
  *
- * @param server        The server instance to stop.
+ * @param server  The server instance to stop.
  *
- * @attribute           destructor true
- * @attribute           class web_server
- * @attribute           method stop
- * @attribute           self server
+ * @attribute destructor  true
+ * @attribute class       web_server
+ * @attribute self        server
+ * @attribute method      stop
  */
 void stop_web_server(web_server server);
 
 /**
  * Returns the next request on a given `web_server` instance
  *
- * @param server        The `web_server` to get the `server_request` from.
+ * @param server  The `web_server` to get the `server_request` from.
  *
- * @attribute           class web_server
- * @attribute           self server
+ * @returns       Returns the next request on the given `web_server` instance.
  *
- * @returns             Returns the next request on the given `web_server` instance.
+ * @attribute class web_server
+ * @attribute self  server
  */
 server_request next_web_request(web_server server);
 
 /**
  * Sends a message to a given `server_request`.
  *
- * @attribute           class server_request
- * @attribute           self r
+ * @param r     The `server_request` to send the response to
+ * @param resp  The messsage, in the form of a `server_response`, to be sent.
  *
- * @param r             The `server_request` to send the response to
- * @param resp          The messsage, in the form of a `server_response`, to be sent.
+ * @attribute class server_request
+ * @attribute self  r
  */
 void send_response(server_request r, server_response resp);
 
 /**
  * Sends a message to a given `server_request`.
  *
- * @attribute           class server_response
- * @attribute           self r
+ * @param r       The request to be sent.
+ * @param message The message to be sent
  *
- * @param r
- * @param message       The message to be sent
+ * @attribute class server_response
  */
 void send_response(server_request r, string message);
 
 /**
  * Requests a URI from the web server.
  *
- * @param r             The request to be sent.
+ * @param r The request to be sent.
+ *
  * @returns Returns the requested URI in the form of a string.
  */
 string request_get_uri(server_request r);

--- a/projects/cmake/CMakeLists.txt
+++ b/projects/cmake/CMakeLists.txt
@@ -11,7 +11,7 @@ set(SK_BIN "../../bin")
 #### SETUP ####
 if (APPLE)
     # MAC OS PROJECT FLAGS
-    set(LIB_FLAGS "-L../../coresdk/lib/mac \
+    set(LIB_FLAGS "-L${SK_LIB}/mac \
                    -framework IOKit \
                    -framework ForceFeedback \
                    -framework CoreFoundation \
@@ -44,7 +44,7 @@ if (APPLE)
                    -ldl")
 # WINDOWS PROJECT FLAGS
 elseif(MSYS)
-    set(LIB_FLAGS "-L../../coresdk/lib/win64 \
+    set(LIB_FLAGS "-L${SK_LIB}/win64 \
                    -L/mingw64/lib \
                    -L/usr/lib \
                    -lSDL2main")


### PR DESCRIPTION
Parser violations in the headerdoc was preventing translation. https://github.com/splashkit/splashkit-translator/pull/9 will list direct links to assist developers with rules and might be nice to add another CI check that makes sure the parser runs OK... @jarmstrong @macite thoughts?