### PR TITLE
Update CI and submodule config

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/splashkit/splashkit-external
 [submodule "tools/translator"]
 	path = tools/translator
-	url = https://github.com/alexcu/splashkit-translator
+	url = https://github.com/splashkit/splashkit-translator

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ before_install:
 branches:
     only:
         - develop
-        - test/ci-for-doc
 
 script:
     - .travis/run.sh


### PR DESCRIPTION
- Update CI to check `develop` branch only
- Point `translator` submodule to https://github.com/splashkit/splashkit-translator instead of https://github.com/alexcu/splashkit-translator