### PR TITLE
DOCS: Move to @returns and add missing required doc

### DIFF
--- a/coresdk/src/coresdk/collisions.h
+++ b/coresdk/src/coresdk/collisions.h
@@ -60,7 +60,7 @@ bool sprite_rect_collision(sprite s, const rectangle& rect);
  * @param  s1 the first `sprite` to test
  * @param  s2 the second `sprite` to test
  *
- * @return return `true` if both `s1` and `s2` are colliding, false otherwise.
+ * @returns return `true` if both `s1` and `s2` are colliding, false otherwise.
  *
  * @attribute class   sprite
  * @attribute method  collide_with_sprite

--- a/coresdk/src/coresdk/images.h
+++ b/coresdk/src/coresdk/images.h
@@ -1,10 +1,11 @@
-//
-//  images.hpp
-//  splashkit
-//
-//  Created by Andrew Cain on 24/07/2016.
-//  Copyright © 2016 Andrew Cain. All rights reserved.
-//
+/**
+ * @header Images
+ * @author Andrew Cain
+ * @brief SplashKit Images allow drawing of bitmaps and sprites to graphic windows.
+ *
+ *
+ * @attribute static images
+ */
 
 #ifndef images_h
 #define images_h
@@ -41,7 +42,7 @@ bool has_bitmap(string name);
  * been loaded.
  *
  * @param  name The name of the bitmap to check.
- * @return      The bitmap with the name specified, which may refer to nothing
+ * @returns      The bitmap with the name specified, which may refer to nothing
  *              if the bitmap has not been loaded.
  */
 bitmap bitmap_named(string name);
@@ -53,12 +54,71 @@ void free_bitmap(bitmap to_delete);
 
 void free_all_bitmaps();
 
+/**
+ * Draws the bitmap supplied into `bmp` to the current window.
+ * at `x` and `y`.
+ *
+ * @param bmp the bitmap which will be drawn to the screen
+ * @param x   the x location which represents where the bitmap
+ *            will be drawn
+ * @param y   the y location which represents where the bitmap
+ *            will be drawn
+ *
+ * @attribute class   bitmap
+ * @attribute method  draw
+ * @attribute self    bmp
+ */
 void draw_bitmap(bitmap bmp, float x, float y);
 
+/**
+ * Draws the bitmap supplied into `bmp` to the current window.
+ * with extra drawing options supplied in `opts` at `x` and `y`.
+ *
+ * @param bmp the bitmap which will be drawn to the screen
+ * @param x     the x location which represents where the bitmap
+ *              will be drawn
+ * @param y     the y location which represents where the bitmap
+ *              will be drawn
+ * @param opts  the `drawing_options` which provide extra information
+ *              for how to draw the `bitmap`
+ *
+ * @attribute class   bitmap
+ * @attribute method  draw
+ * @attribute self    bmp
+ * @attribute suffix  with_options
+ */
 void draw_bitmap(bitmap bmp, float x, float y, drawing_options opts);
 
+/**
+ * Searches and draws a bitmap with name `name` to the current window.
+ * with extra drawing options supplied in `opts` at `x` and `y`.
+ *
+ * @param name  the name of the bitmap which will be drawn to the screen
+ * @param x     the x location which represents where the bitmap
+ *              will be drawn
+ * @param y     the y location which represents where the bitmap
+ *              will be drawn
+ *
+ * @attribute method  draw_bitmap
+ * @attribute suffix  named
+ */
 void draw_bitmap(string name, float x, float y);
 
+/**
+ * Searches and draws a bitmap with name `name` to the current window.
+ * with extra drawing options supplied in `opts` at `x` and `y`.
+ *
+ * @param name  the name of the bitmap which will be drawn to the screen
+ * @param x     the x location which represents where the bitmap
+ *              will be drawn
+ * @param y     the y location which represents where the bitmap
+ *              will be drawn
+ * @param opts  the `drawing_options` which provide extra information
+ *              for how to draw the `bitmap`
+ *
+ * @attribute method  draw_bitmap
+ * @attribute suffix  named_with_options
+ */
 void draw_bitmap(string name, float x, float y, drawing_options opts);
 
 bitmap create_bitmap(string name, int width, int height);
@@ -68,7 +128,7 @@ bitmap create_bitmap(string name, int width, int height);
  * string for created bitmaps.
  *
  * @param  bmp The bitmap to get the filename from.
- * @return     The file name of the bitmap.
+ * @returns     The file name of the bitmap.
  */
 string bitmap_filename(bitmap bmp);
 
@@ -77,7 +137,7 @@ string bitmap_filename(bitmap bmp);
  * access this bitmap.
  *
  * @param  bmp The bitmap to get the name from.
- * @return     The name of the bitmap.
+ * @returns     The name of the bitmap.
  */
 string bitmap_name(bitmap bmp);
 
@@ -94,7 +154,7 @@ int bitmap_width(string name);
  * get the height of a cell using `bitmap_cell_height`.
  *
  * @param  bmp The bitmap to get the details from.
- * @return     The height of the bitmap.
+ * @returns     The height of the bitmap.
  */
 int bitmap_height(bitmap bmp);
 
@@ -103,7 +163,7 @@ int bitmap_height(bitmap bmp);
  * get the height of a cell using `bitmap_cell_height`.
  *
  * @param  name The name of the bitmap to get the details from.
- * @return      The height of the bitmap.
+ * @returns      The height of the bitmap.
  */
 int bitmap_height(string name);
 
@@ -137,7 +197,7 @@ int bitmap_cell_height(bitmap bmp);
  * `bitmap_set_cell_details`.
  *
  * @param  bmp The bitmap to get the details from.
- * @return     The number of rows of cells in the bitmap.
+ * @returns     The number of rows of cells in the bitmap.
  */
 int bitmap_cell_rows(bitmap bmp);
 
@@ -215,7 +275,7 @@ circle bitmap_cell_circle(bitmap bmp, float x, float y);
  *
  * @param  bmp The bitmap to encompass.
  * @param  pt  The point where the bitmap is located.
- * @return     A circle that surrounds the bitmap.
+ * @returns     A circle that surrounds the bitmap.
  */
 circle bitmap_circle(bitmap bmp, const point_2d &pt);
 
@@ -224,7 +284,7 @@ circle bitmap_circle(bitmap bmp, const point_2d &pt);
  * This is setup using `bitmap_set_cell_details`
  *
  * @param  bmp The bitmap to check
- * @return     The number of cell columns
+ * @returns     The number of cell columns
  */
 int bitmap_cell_columns(bitmap bmp);
 

--- a/coresdk/src/coresdk/networking.h
+++ b/coresdk/src/coresdk/networking.h
@@ -14,7 +14,7 @@ using namespace std;
  *
  * @param a_hex hexadecimal ipv4 string to convert
  *
- * @return standard ipv4 address using format X.X.X.X
+ * @returns standard ipv4 address using format X.X.X.X
  */
 string hex_str_to_ipv4(const string &a_hex);
 
@@ -26,7 +26,7 @@ string hex_str_to_ipv4(const string &a_hex);
  *
  * @param a_hex hexadecimal string to convert
  *
- * @return decimal representation of supplied hex string
+ * @returns decimal representation of supplied hex string
  */
 string hex_to_dec_string(const string &a_hex);
 
@@ -38,7 +38,7 @@ string hex_to_dec_string(const string &a_hex);
  *
  * @param a_ip ipv4 address to encode
  *
- * @return encoded ipv4 string
+ * @returns encoded ipv4 string
  */
 unsigned int ipv4_to_dec(const string &a_ip);
 
@@ -50,7 +50,7 @@ unsigned int ipv4_to_dec(const string &a_ip);
  *
  * @param ip integer to be decoded
  *
- * @return ipv4 address string in X.X.X.X format
+ * @returns ipv4 address string in X.X.X.X format
  */
 string ipv4_to_str(unsigned int ip);
 

--- a/coresdk/src/coresdk/point_geometry.h
+++ b/coresdk/src/coresdk/point_geometry.h
@@ -66,7 +66,7 @@ bool point_in_rectangle(const point_2d &pt, const rectangle &rect);
  *
  * @param pt    The point to test.
  * @param q     The quad to check if the point is within.
- * @return      True if pt lies within the area of q.
+ * @returns      True if pt lies within the area of q.
  */
 bool point_in_quad(const point_2d &pt, const quad &q);
 

--- a/coresdk/src/coresdk/sprites.h
+++ b/coresdk/src/coresdk/sprites.h
@@ -129,7 +129,7 @@ sprite create_sprite(const string &bitmap_name);
  * @param bitmap_name     The name of the bitmap to use as the sprite's image.
  * @param animation_name  The name of the animation script to use for this
  *                        sprite.
- * @return                The new sprite with the image and animation.
+ * @returns                The new sprite with the image and animation.
  *
  * @attribute class sprite
  * @attribute constructor true

--- a/coresdk/src/coresdk/window_manager.h
+++ b/coresdk/src/coresdk/window_manager.h
@@ -76,7 +76,7 @@ void close_all_windows();
  *
  * @param caption The name of the window to check for.
  *
- * @return Returns `true` if there is a window with the given `caption`
+ * @returns Returns `true` if there is a window with the given `caption`
  *          which has has been loaded.
  *
  */
@@ -88,7 +88,7 @@ bool has_window(string caption);
  *
  * @param  caption the `string` name of the window.
  *
- * @return Returns a `window` with the name specified by `caption`
+ * @returns Returns a `window` with the name specified by `caption`
  *
  * @attribute method window_named
  * @attribute class  window
@@ -108,7 +108,7 @@ void set_current_window(const string &name);
  *
  * @param  wind the `window` to be closed
  *
- * @return Returns `true` if the window is closed,
+ * @returns Returns `true` if the window is closed,
  * `false` if there is an error.
  *
  * @attribute class window
@@ -128,6 +128,15 @@ bool window_close_requested(window wind);
  */
 bool window_close_requested(const string &name);
 
+/**
+ * Refreshes the window `wind`.
+ *
+ * @param  wind the `window` to refresh.
+ *
+ * @attribute method  refresh
+ * @attribute class   window
+ * @attribute self    wind
+ */
 void refresh_window(window wind);
 
 /**


### PR DESCRIPTION
This PR will:
* Move to ```@returns``` from ```@return```
* add missing headerdoc for method required for cave-escape 