### PR TITLE
Fix cmake project for macOS

### DIFF
--- a/coresdk/src/coresdk/animations.cpp
+++ b/coresdk/src/coresdk/animations.cpp
@@ -854,10 +854,4 @@ namespace splashkit_lib
             anim->entered_frame  = false;
         }
     }
-
-    animation create_animation(const string &script_name, int idx)
-    {
-      // TODO: Not yet implemented
-      return nullptr;
-    }
 }

--- a/coresdk/src/coresdk/animations.cpp
+++ b/coresdk/src/coresdk/animations.cpp
@@ -854,4 +854,10 @@ namespace splashkit_lib
             anim->entered_frame  = false;
         }
     }
+
+    animation create_animation(const string &script_name, int idx)
+    {
+      // TODO: Not yet implemented
+      return nullptr;
+    }
 }

--- a/coresdk/src/coresdk/animations.h
+++ b/coresdk/src/coresdk/animations.h
@@ -191,15 +191,6 @@ namespace splashkit_lib
     animation create_animation(animation_script script, int idx, bool with_sound);
 
     /**
-     * Creates an animation from an `animation_script`.
-     *
-     * @param script        The name of the `animation_script` to create the `animation` from.
-     * @param idx           The index of the `animation` to create.
-     * @returns Returns the newly created `animation_script`.
-     */
-    animation create_animation(const string &script_name, int idx);
-
-    /**
      * Disposes of the resources used in the animation.
      *
      * @param ani           The `animation` to be disposed of.

--- a/projects/cmake/CMakeLists.txt
+++ b/projects/cmake/CMakeLists.txt
@@ -152,7 +152,18 @@ if (MSYS)
                                            pthread
                                            stdc++
                                            ws2_32)
+elseif(APPLE)
+    # To make a universal single static library from dependent
+    # static libraries, run libtool on SplashKitBackend
+    file(GLOB APPLE_STATIC_LIBS
+        "${SK_LIB}/mac/*.a"
+    )
+    add_custom_command(TARGET SplashKitBackend POST_BUILD
+      COMMAND /usr/bin/libtool -static -o $<TARGET_FILE:SplashKitBackend>
+      $<TARGET_FILE:SplashKitBackend> ${APPLE_STATIC_LIBS}
+    )
 endif()
+
 
 # SET OUTPUT TO /path/to/splashkit/out/lib
 set_target_properties(SplashKitBackend
@@ -187,14 +198,3 @@ endif()
 
 install(TARGETS SplashKitBackend DESTINATION lib)
 install(FILES ${INCLUDE_FILES} DESTINATION include/SplashKitBackend)
-
-# Use libtool to copy in dependent static libs into SplashKitBackend.a
-if (APPLE)
-    file(GLOB APPLE_STATIC_LIBS
-        "${SK_LIB}/mac/*.a"
-    )
-    add_custom_command(TARGET SplashKitBackend POST_BUILD
-      COMMAND /usr/bin/libtool -static -o $<TARGET_FILE:SplashKitBackend>
-      $<TARGET_FILE:SplashKitBackend> ${APPLE_STATIC_LIBS}
-    )
-endif()

--- a/projects/cmake/CMakeLists.txt
+++ b/projects/cmake/CMakeLists.txt
@@ -190,8 +190,11 @@ install(FILES ${INCLUDE_FILES} DESTINATION include/SplashKitBackend)
 
 # Use libtool to copy in dependent static libs into SplashKitBackend.a
 if (APPLE)
-  execute_process(COMMAND libtool -static -o "${SK_OUT}/lib/libSplashKitBackend.a"
-                                             "${SK_OUT}/lib/libSplashKitBackend.a"
-                                             "${SK_LIB}/mac/*.a"
-  )
+    file(GLOB APPLE_STATIC_LIBS
+        "${SK_LIB}/mac/*.a"
+    )
+    add_custom_command(TARGET SplashKitBackend POST_BUILD
+      COMMAND /usr/bin/libtool -static -o $<TARGET_FILE:SplashKitBackend>
+      $<TARGET_FILE:SplashKitBackend> ${APPLE_STATIC_LIBS}
+    )
 endif()


### PR DESCRIPTION
The compilation on macOS was not making a universal static library, causing linker issues.

We now run `libtool` copying all dependent static libs into `libSplashKitBackend.a`

I had to add back the `create_animation` implementation as per comment: https://github.com/splashkit/splashkit/commit/f745254ea321dc4d060a7e0b2fef24b5bea90821#commitcomment-18959334