### PR TITLE
Fix translator errors

### DIFF
--- a/coresdk/src/coresdk/circle_geometry.h
+++ b/coresdk/src/coresdk/circle_geometry.h
@@ -28,8 +28,8 @@ namespace splashkit_lib
      * @param  y      The y location of the circle
      * @param  radius The radius of the circle
      * @return        A circle at the indicatd point and radius
-     * 
-     * @attribute suffic from_points
+     *
+     * @attribute suffix from_points
      */
     circle circle_at(float x, float y, float radius);
 

--- a/coresdk/src/coresdk/database.h
+++ b/coresdk/src/coresdk/database.h
@@ -135,7 +135,7 @@ namespace splashkit_lib
      * @returns Returns the `query_result` which represents
      * the result of perfoming `sql` on the database at `database_name`.
      *
-     * @attribute unique  run_sql_from_name
+     * @attribute suffix from_name
      */
     query_result run_sql(string database_name, string sql);
 
@@ -277,7 +277,7 @@ namespace splashkit_lib
      * @attribute getter  successful
      */
     bool query_success(query_result result);
-    
+
     /**
      * Frees the SplashKit resources associated with the database.
      *
@@ -287,20 +287,20 @@ namespace splashkit_lib
      * @attribute destructor  true
      */
     void free_database(database db_to_close);
-    
+
     /**
      * Frees the SplashKit resources associated with the database at a given name.
      *
      * @param name_of_db_to_close The `string` denoting where the database is which should be released.
      *
-     * @attribute unique  free_database_named
+     * @attribute suffix named
      */
     void free_database(string name_of_db_to_close);
-    
+
     /**
      * Releases all of the databases which have been loaded.
      */
     void free_all_databases();
-    
+
 #endif /* database_h */
 }

--- a/coresdk/src/coresdk/sprites.h
+++ b/coresdk/src/coresdk/sprites.h
@@ -365,7 +365,6 @@ namespace splashkit_lib
      *
      * @param s     The sprite to hide the layer of.
      * @param name  The name of the layer to hide.
-     * @returns     The index of the layer hidden, or -1 if no layer found.
      *
      * @attribute class sprite
      * @attribute method hide_layer
@@ -378,7 +377,6 @@ namespace splashkit_lib
      *
      * @param s     The sprite to hide the layer of.
      * @param id    The index of the layer to hide.
-     * @returns     The index of the layer hidden, or -1 if no layer found.
      *
      * @attribute class sprite
      * @attribute method Hide_layer

--- a/coresdk/src/coresdk/timers.h
+++ b/coresdk/src/coresdk/timers.h
@@ -72,7 +72,7 @@ namespace splashkit_lib
      * @param  name The name of the timer
      * @return      True if SplashKit has created a timer with that name.
      *
-     * @attribute suffic _named
+     * @attribute suffix _named
      */
     bool has_timer(string name);
 
@@ -95,7 +95,7 @@ namespace splashkit_lib
      *
      * @param name The name of the timer
      *
-     * @attribute suffic _named
+     * @attribute suffix _named
      */
     void start_timer(string name);
 
@@ -116,7 +116,7 @@ namespace splashkit_lib
      *
      * @param name The name of the timer
      *
-     * @attribute suffic _named
+     * @attribute suffix _named
      */
     void stop_timer(string name);
 
@@ -137,7 +137,7 @@ namespace splashkit_lib
      *
      * @param name The name of the timer
      *
-     * @attribute suffic _named
+     * @attribute suffix _named
      */
     void pause_timer(string name);
 
@@ -156,7 +156,7 @@ namespace splashkit_lib
      *
      * @param name The name of the timer
      *
-     * @attribute suffic _named
+     * @attribute suffix _named
      */
     void resume_timer(string name);
 
@@ -175,7 +175,7 @@ namespace splashkit_lib
      *
      * @param name The name of the timer
      *
-     * @attribute suffic _named
+     * @attribute suffix _named
      */
     void reset_timer(string name);
 
@@ -204,7 +204,7 @@ namespace splashkit_lib
      *              timer was created (excluding the time the timer was
      *              paused)
      *
-     * @attribute suffic _named
+     * @attribute suffix _named
      */
     unsigned int timer_ticks(string name);
 
@@ -225,7 +225,7 @@ namespace splashkit_lib
      * @param  name   The name of the timer
      * @return        True if the timer is paused
      *
-     * @attribute suffic _named
+     * @attribute suffix _named
      */
     bool timer_paused(string name);
 
@@ -246,7 +246,7 @@ namespace splashkit_lib
      * @param  name   The name of the timer
      * @return        True if the timer has been started
      *
-     * @attribute suffic _named
+     * @attribute suffix _named
      */
     bool timer_started(string name);
 }


### PR DESCRIPTION
- Remove `@returns` for procedures
- Replace deprecated attribute `unique` to `suffix`
- Replace `suffic` to `suffix` in certain functions 