### PR TITLE
Development

### DIFF
--- a/coresdk/src/backend/web_driver.cpp
+++ b/coresdk/src/backend/web_driver.cpp
@@ -171,9 +171,9 @@ namespace splashkit_lib
 
         result->id = HTTP_RESPONSE_PTR;
 
-        int status;
+        long status;
         curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &status);
-        result->code = code_to_status(status);
+        result->code = code_to_status((int)status);
 
         char *content_type;
         curl_easy_getinfo(curl_handle, CURLINFO_CONTENT_TYPE, &content_type);

--- a/coresdk/src/coresdk/circle_drawing.cpp
+++ b/coresdk/src/coresdk/circle_drawing.cpp
@@ -51,7 +51,6 @@ namespace splashkit_lib
         draw_circle(clr, c.center.x, c.center.y, c.radius, option_defaults());
     }
 
-
     void fill_circle(color clr, float x, float y, float radius, drawing_options opts)
     {
         sk_drawing_surface *surface;

--- a/coresdk/src/coresdk/circle_drawing.h
+++ b/coresdk/src/coresdk/circle_drawing.h
@@ -187,7 +187,5 @@ namespace splashkit_lib
      */
     void draw_circle_on_bitmap(bitmap destination, color clr, float x, float y, float radius);
 
-    
-
 }
 #endif /* circle_drawing_hpp */

--- a/coresdk/src/coresdk/circle_drawing.h
+++ b/coresdk/src/coresdk/circle_drawing.h
@@ -122,7 +122,6 @@ namespace splashkit_lib
      */
     void fill_circle(color clr, const circle &c);
     
-    
     /**
      *  Draw a circle to the window using the supplied drawing options. The circle is centred on its x, y
      *  coordinates, and has the provided radius.

--- a/coresdk/src/coresdk/ellipse_drawing.cpp
+++ b/coresdk/src/coresdk/ellipse_drawing.cpp
@@ -102,4 +102,44 @@ namespace splashkit_lib
     {
         fill_ellipse(clr, rect.x, rect.y, rect.width, rect.height, option_defaults());
     }
+    
+    void draw_ellipse_on_window(window destination, color clr, float x, float y, float width, float height, drawing_options opts)
+    {
+        draw_ellipse(clr, x, y, width, height, option_draw_to(destination, opts));
+    }
+    
+    void draw_ellipse_on_window(window destination, color clr, float x, float y, float width, float height)
+    {
+        draw_ellipse(clr, x, y, width, height, option_draw_to(destination));
+    }
+    
+    void draw_ellipse_on_window(window destination, color clr, const rectangle rect, drawing_options opts)
+    {
+        draw_ellipse(clr, rect, option_draw_to(destination, opts));
+    }
+    
+    void draw_ellipse_on_window(window destination, color clr, const rectangle rect)
+    {
+        draw_ellipse(clr, rect, option_draw_to(destination));
+    }
+    
+    void fill_ellipse_on_window(window destination, color clr, float x, float y, float width, float height, drawing_options opts)
+    {
+        fill_ellipse(clr, x, y, width, height, option_draw_to(destination, opts));
+    }
+    
+    void fill_ellipse_on_window(window destination, color clr, float x, float y, float width, float height)
+    {
+        fill_ellipse(clr, x, y, width, height, option_draw_to(destination));
+    }
+    
+    void fill_ellipse_on_window(window destination, color clr, const rectangle rect, drawing_options opts)
+    {
+        fill_ellipse(clr, rect, option_draw_to(destination, opts));
+    }
+    
+    void fill_ellipse_on_window(window destination, color clr, const rectangle rect)
+    {
+        fill_ellipse(clr, rect, option_draw_to(destination));
+    }
 }

--- a/coresdk/src/coresdk/ellipse_drawing.cpp
+++ b/coresdk/src/coresdk/ellipse_drawing.cpp
@@ -142,4 +142,44 @@ namespace splashkit_lib
     {
         fill_ellipse(clr, rect, option_draw_to(destination));
     }
+
+    void draw_ellipse_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height, drawing_options opts)
+    {
+        draw_ellipse(clr, x, y, width, height, option_draw_to(destination, opts));
+    }
+    
+    void draw_ellipse_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height)
+    {
+        draw_ellipse(clr, x, y, width, height, option_draw_to(destination));
+    }
+    
+    void draw_ellipse_on_bitmap(bitmap destination, color clr, const rectangle rect, drawing_options opts)
+    {
+        draw_ellipse(clr, rect, option_draw_to(destination, opts));
+    }
+    
+    void draw_ellipse_on_bitmap(bitmap destination, color clr, const rectangle rect)
+    {
+        draw_ellipse(clr, rect, option_draw_to(destination));
+    }
+    
+    void fill_ellipse_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height, drawing_options opts)
+    {
+        fill_ellipse(clr, x, y, width, height, option_draw_to(destination, opts));
+    }
+    
+    void fill_ellipse_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height)
+    {
+        fill_ellipse(clr, x, y, width, height, option_draw_to(destination));
+    }
+    
+    void fill_ellipse_on_bitmap(bitmap destination, color clr, const rectangle rect, drawing_options opts)
+    {
+        fill_ellipse(clr, rect, option_draw_to(destination, opts));
+    }
+    
+    void fill_ellipse_on_bitmap(bitmap destination, color clr, const rectangle rect)
+    {
+        fill_ellipse(clr, rect, option_draw_to(destination));
+    }
 }

--- a/coresdk/src/coresdk/ellipse_drawing.h
+++ b/coresdk/src/coresdk/ellipse_drawing.h
@@ -120,5 +120,129 @@ namespace splashkit_lib
      * @attribute suffix  within_rectangle
      */
     void fill_ellipse(color clr, const rectangle rect);
+    
+    
+    
+    
+    
+    
+    
+    /**
+     * Draws an ellipse to the window, using the provided location, size, and drawing options.
+     *
+     * At this stage ellipse drawing is not affected by line width from the
+     * drawing options.
+     *
+     * @param destination the window to draw the ellipse on
+     * @param clr    The color of the ellipse
+     * @param x      The distance from the left of the bitmap or window to the
+     *               left edge of the ellipse
+     * @param y      The distance from the top of the bitmap or window to the
+     *               top edge of the ellipse
+     * @param width  The width of the ellipse
+     * @param height The height of the ellipse
+     * @param opts   The drawing options
+     *
+     * @attribute suffix  with_options
+     */
+    void draw_ellipse_on_window(window destination, color clr, float x, float y, float width, float height, drawing_options opts);
+    
+    /**
+     * Draws an ellipse on the given window, using the provided location, and size.
+     *
+     * @param destination the window to draw the ellipse on
+     * @param clr    The color of the ellipse
+     * @param x      The distance from the left of the bitmap or window to the
+     *               left edge of the ellipse
+     * @param y      The distance from the top of the bitmap or window to the
+     *               top edge of the ellipse
+     * @param width  The width of the ellipse
+     * @param height The height of the ellipse
+     */
+    void draw_ellipse_on_window(window destination, color clr, float x, float y, float width, float height);
+    
+    /**
+     * Draws an ellipse on the given window, using the provided location, size, and drawing options.
+     *
+     * At this stage ellipse drawing is not affected by line width from the
+     * drawing options.
+     *
+     * @param destination the window to draw the ellipse on
+     * @param clr    The color of the ellipse
+     * @param rect   Indicates the location and size of the ellipse
+     * @param opts   The drawing options
+     *
+     * @attribute suffix  within_rectangle_with_options
+     */
+    void draw_ellipse_on_window(window destination, color clr, const rectangle rect, drawing_options opts);
+    
+    /**
+     * Draws an ellipse on the given window, using the provided location, and size.
+     *
+     * @param destination the window to draw the ellipse on
+     * @param clr    The color of the ellipse
+     * @param rect   Indicates the location and size of the ellipse
+     *
+     * @attribute suffix  within_rectangle
+     */
+    void draw_ellipse_on_window(window destination, color clr, const rectangle rect);
+    
+    /**
+     * Fills an ellipse on the given window, using the provided location, size, and drawing options.
+     *
+     * @param destination the window to draw the ellipse on
+     * @param clr    The color of the ellipse
+     * @param x      The distance from the left of the bitmap or window to the
+     *               left edge of the ellipse
+     * @param y      The distance from the top of the bitmap or window to the
+     *               top edge of the ellipse
+     * @param width  The width of the ellipse
+     * @param height The height of the ellipse
+     * @param opts   The drawing options
+     *
+     * @attribute suffix  with_options
+     */
+    void fill_ellipse_on_window(window destination, color clr, float x, float y, float width, float height, drawing_options opts);
+    
+    /**
+     * Fills an ellipse on the given window, using the provided location, and size.
+     *
+     * @param destination the window to draw the ellipse on
+     * @param clr    The color of the ellipse
+     * @param x      The distance from the left of the bitmap or window to the
+     *               left edge of the ellipse
+     * @param y      The distance from the top of the bitmap or window to the
+     *               top edge of the ellipse
+     * @param width  The width of the ellipse
+     * @param height The height of the ellipse
+     */
+    void fill_ellipse_on_window(window destination, color clr, float x, float y, float width, float height);
+    
+    /**
+     * Fills an ellipse on the given window, using the provided location, size, and drawing options.
+     *
+     * At this stage ellipse drawing is not affected by line width from the
+     * drawing options.
+     *
+     * @param destination the window to draw the ellipse on
+     * @param clr    The color of the ellipse
+     * @param rect   Indicates the location and size of the ellipse
+     * @param opts   The drawing options
+     *
+     * @attribute suffix  within_rectangle_with_options
+     */
+    void fill_ellipse_on_window(window destination, color clr, const rectangle rect, drawing_options opts);
+    
+    /**
+     * Fill an ellipse on the given window, using the provided location, and size.
+     *
+     * @param destination the window to draw the ellipse on
+     * @param clr    The color of the ellipse
+     * @param rect   Indicates the location and size of the ellipse
+     *
+     * @attribute suffix  within_rectangle
+     */
+    void fill_ellipse_on_window(window destination, color clr, const rectangle rect);
+
 }
 #endif /* ellipse_drawing_h */

--- a/coresdk/src/coresdk/ellipse_drawing.h
+++ b/coresdk/src/coresdk/ellipse_drawing.h
@@ -137,6 +137,7 @@ namespace splashkit_lib
      * @param height The height of the ellipse
      * @param opts   The drawing options
      *
+     * @attribute class   window
      * @attribute suffix  with_options
      */
     void draw_ellipse_on_window(window destination, color clr, float x, float y, float width, float height, drawing_options opts);
@@ -152,6 +153,8 @@ namespace splashkit_lib
      *               top edge of the ellipse
      * @param width  The width of the ellipse
      * @param height The height of the ellipse
+     *
+     * @attribute class   window
      */
     void draw_ellipse_on_window(window destination, color clr, float x, float y, float width, float height);
     
@@ -166,6 +169,7 @@ namespace splashkit_lib
      * @param rect   Indicates the location and size of the ellipse
      * @param opts   The drawing options
      *
+     * @attribute class   window
      * @attribute suffix  within_rectangle_with_options
      */
     void draw_ellipse_on_window(window destination, color clr, const rectangle rect, drawing_options opts);
@@ -177,6 +181,7 @@ namespace splashkit_lib
      * @param clr    The color of the ellipse
      * @param rect   Indicates the location and size of the ellipse
      *
+     * @attribute class   window
      * @attribute suffix  within_rectangle
      */
     void draw_ellipse_on_window(window destination, color clr, const rectangle rect);
@@ -194,6 +199,7 @@ namespace splashkit_lib
      * @param height The height of the ellipse
      * @param opts   The drawing options
      *
+     * @attribute class   window
      * @attribute suffix  with_options
      */
     void fill_ellipse_on_window(window destination, color clr, float x, float y, float width, float height, drawing_options opts);
@@ -209,6 +215,8 @@ namespace splashkit_lib
      *               top edge of the ellipse
      * @param width  The width of the ellipse
      * @param height The height of the ellipse
+     *
+     * @attribute class   window
      */
     void fill_ellipse_on_window(window destination, color clr, float x, float y, float width, float height);
     
@@ -223,6 +231,7 @@ namespace splashkit_lib
      * @param rect   Indicates the location and size of the ellipse
      * @param opts   The drawing options
      *
+     * @attribute class   window
      * @attribute suffix  within_rectangle_with_options
      */
     void fill_ellipse_on_window(window destination, color clr, const rectangle rect, drawing_options opts);
@@ -234,6 +243,7 @@ namespace splashkit_lib
      * @param clr    The color of the ellipse
      * @param rect   Indicates the location and size of the ellipse
      *
+     * @attribute class   window
      * @attribute suffix  within_rectangle
      */
     void fill_ellipse_on_window(window destination, color clr, const rectangle rect);
@@ -254,6 +264,7 @@ namespace splashkit_lib
      * @param height The height of the ellipse
      * @param opts   The drawing options
      *
+     * @attribute class   bitmap
      * @attribute suffix  with_options
      */
     void draw_ellipse_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height, drawing_options opts);
@@ -269,6 +280,8 @@ namespace splashkit_lib
      *               top edge of the ellipse
      * @param width  The width of the ellipse
      * @param height The height of the ellipse
+     *
+     * @attribute class   bitmap
      */
     void draw_ellipse_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height);
     
@@ -283,6 +296,7 @@ namespace splashkit_lib
      * @param rect   Indicates the location and size of the ellipse
      * @param opts   The drawing options
      *
+     * @attribute class   bitmap
      * @attribute suffix  within_rectangle_with_options
      */
     void draw_ellipse_on_bitmap(bitmap destination, color clr, const rectangle rect, drawing_options opts);
@@ -294,6 +308,7 @@ namespace splashkit_lib
      * @param clr    The color of the ellipse
      * @param rect   Indicates the location and size of the ellipse
      *
+     * @attribute class   bitmap
      * @attribute suffix  within_rectangle
      */
     void draw_ellipse_on_bitmap(bitmap destination, color clr, const rectangle rect);
@@ -311,6 +326,7 @@ namespace splashkit_lib
      * @param height The height of the ellipse
      * @param opts   The drawing options
      *
+     * @attribute class   bitmap
      * @attribute suffix  with_options
      */
     void fill_ellipse_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height, drawing_options opts);
@@ -326,6 +342,8 @@ namespace splashkit_lib
      *               top edge of the ellipse
      * @param width  The width of the ellipse
      * @param height The height of the ellipse
+     *
+     * @attribute class   bitmap
      */
     void fill_ellipse_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height);
     
@@ -340,6 +358,7 @@ namespace splashkit_lib
      * @param rect   Indicates the location and size of the ellipse
      * @param opts   The drawing options
      *
+     * @attribute class   bitmap
      * @attribute suffix  within_rectangle_with_options
      */
     void fill_ellipse_on_bitmap(bitmap destination, color clr, const rectangle rect, drawing_options opts);
@@ -351,6 +370,7 @@ namespace splashkit_lib
      * @param clr    The color of the ellipse
      * @param rect   Indicates the location and size of the ellipse
      *
+     * @attribute class   bitmap
      * @attribute suffix  within_rectangle
      */
     void fill_ellipse_on_bitmap(bitmap destination, color clr, const rectangle rect);

--- a/coresdk/src/coresdk/ellipse_drawing.h
+++ b/coresdk/src/coresdk/ellipse_drawing.h
@@ -121,12 +121,6 @@ namespace splashkit_lib
      */
     void fill_ellipse(color clr, const rectangle rect);
     
-    
-    
-    
-    
-    
-    
     /**
      * Draws an ellipse to the window, using the provided location, size, and drawing options.
      *
@@ -243,6 +237,123 @@ namespace splashkit_lib
      * @attribute suffix  within_rectangle
      */
     void fill_ellipse_on_window(window destination, color clr, const rectangle rect);
+    
+    /**
+     * Draws an ellipse to the bitmap, using the provided location, size, and drawing options.
+     *
+     * At this stage ellipse drawing is not affected by line width from the
+     * drawing options.
+     *
+     * @param destination the bitmap to draw the ellipse on
+     * @param clr    The color of the ellipse
+     * @param x      The distance from the left of the bitmap or bitmap to the
+     *               left edge of the ellipse
+     * @param y      The distance from the top of the bitmap or bitmap to the
+     *               top edge of the ellipse
+     * @param width  The width of the ellipse
+     * @param height The height of the ellipse
+     * @param opts   The drawing options
+     *
+     * @attribute suffix  with_options
+     */
+    void draw_ellipse_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height, drawing_options opts);
+    
+    /**
+     * Draws an ellipse on the given bitmap, using the provided location, and size.
+     *
+     * @param destination the bitmap to draw the ellipse on
+     * @param clr    The color of the ellipse
+     * @param x      The distance from the left of the bitmap or bitmap to the
+     *               left edge of the ellipse
+     * @param y      The distance from the top of the bitmap or bitmap to the
+     *               top edge of the ellipse
+     * @param width  The width of the ellipse
+     * @param height The height of the ellipse
+     */
+    void draw_ellipse_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height);
+    
+    /**
+     * Draws an ellipse on the given bitmap, using the provided location, size, and drawing options.
+     *
+     * At this stage ellipse drawing is not affected by line width from the
+     * drawing options.
+     *
+     * @param destination the bitmap to draw the ellipse on
+     * @param clr    The color of the ellipse
+     * @param rect   Indicates the location and size of the ellipse
+     * @param opts   The drawing options
+     *
+     * @attribute suffix  within_rectangle_with_options
+     */
+    void draw_ellipse_on_bitmap(bitmap destination, color clr, const rectangle rect, drawing_options opts);
+    
+    /**
+     * Draws an ellipse on the given bitmap, using the provided location, and size.
+     *
+     * @param destination the bitmap to draw the ellipse on
+     * @param clr    The color of the ellipse
+     * @param rect   Indicates the location and size of the ellipse
+     *
+     * @attribute suffix  within_rectangle
+     */
+    void draw_ellipse_on_bitmap(bitmap destination, color clr, const rectangle rect);
+    
+    /**
+     * Fills an ellipse on the given bitmap, using the provided location, size, and drawing options.
+     *
+     * @param destination the bitmap to draw the ellipse on
+     * @param clr    The color of the ellipse
+     * @param x      The distance from the left of the bitmap or bitmap to the
+     *               left edge of the ellipse
+     * @param y      The distance from the top of the bitmap or bitmap to the
+     *               top edge of the ellipse
+     * @param width  The width of the ellipse
+     * @param height The height of the ellipse
+     * @param opts   The drawing options
+     *
+     * @attribute suffix  with_options
+     */
+    void fill_ellipse_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height, drawing_options opts);
+    
+    /**
+     * Fills an ellipse on the given bitmap, using the provided location, and size.
+     *
+     * @param destination the bitmap to draw the ellipse on
+     * @param clr    The color of the ellipse
+     * @param x      The distance from the left of the bitmap or bitmap to the
+     *               left edge of the ellipse
+     * @param y      The distance from the top of the bitmap or bitmap to the
+     *               top edge of the ellipse
+     * @param width  The width of the ellipse
+     * @param height The height of the ellipse
+     */
+    void fill_ellipse_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height);
+    
+    /**
+     * Fills an ellipse on the given bitmap, using the provided location, size, and drawing options.
+     *
+     * At this stage ellipse drawing is not affected by line width from the
+     * drawing options.
+     *
+     * @param destination the bitmap to draw the ellipse on
+     * @param clr    The color of the ellipse
+     * @param rect   Indicates the location and size of the ellipse
+     * @param opts   The drawing options
+     *
+     * @attribute suffix  within_rectangle_with_options
+     */
+    void fill_ellipse_on_bitmap(bitmap destination, color clr, const rectangle rect, drawing_options opts);
+    
+    /**
+     * Fill an ellipse on the given bitmap, using the provided location, and size.
+     *
+     * @param destination the bitmap to draw the ellipse on
+     * @param clr    The color of the ellipse
+     * @param rect   Indicates the location and size of the ellipse
+     *
+     * @attribute suffix  within_rectangle
+     */
+    void fill_ellipse_on_bitmap(bitmap destination, color clr, const rectangle rect);
 
 }
 #endif /* ellipse_drawing_h */

--- a/coresdk/src/coresdk/images.cpp
+++ b/coresdk/src/coresdk/images.cpp
@@ -266,6 +266,26 @@ namespace splashkit_lib
         sk_draw_bitmap(&bmp->image.surface, dest, src_data, 4, dst_data, 7, flip);
     }
 
+    void draw_bitmap_on_window(window destination, bitmap bmp, float x, float y)
+    {
+        draw_bitmap(bmp, x, y, option_draw_to(destination));
+    }
+
+    void draw_bitmap_on_window(window destination, bitmap bmp, float x, float y, drawing_options opts)
+    {
+        draw_bitmap(bmp, x, y, option_draw_to(destination, opts));
+    }
+
+    void draw_bitmap_on_bitmap(bitmap destination, bitmap bmp, float x, float y)
+    {
+        draw_bitmap(bmp, x, y, option_draw_to(destination));
+    }
+
+    void draw_bitmap_on_bitmap(bitmap destination, bitmap bmp, float x, float y, drawing_options opts)
+    {
+        draw_bitmap(bmp, x, y, option_draw_to(destination, opts));
+    }
+
     void draw_bitmap(string name, float x, float y)
     {
         draw_bitmap(bitmap_named(name), x, y, option_defaults());

--- a/coresdk/src/coresdk/images.h
+++ b/coresdk/src/coresdk/images.h
@@ -108,7 +108,7 @@ namespace splashkit_lib
      * Draws the bitmap supplied into `bmp` to the given window.
      * at `x` and `y`.
      *
-     * @param window the window to draw the bitmap to
+     * @param destination the window to draw the bitmap to
      * @param bmp the bitmap which will be drawn to the screen
      * @param x   the x location which represents where the bitmap
      *            will be drawn
@@ -117,7 +117,7 @@ namespace splashkit_lib
      *
      * @attribute class   window
      * @attribute method  draw
-     * @attribute self    bmp
+     * @attribute self    destination
      */
     void draw_bitmap_on_window(window destination, bitmap bmp, float x, float y);
 
@@ -125,7 +125,7 @@ namespace splashkit_lib
      * Draws the bitmap supplied into `bmp` to the given window.
      * with extra drawing options supplied in `opts` at `x` and `y`.
      *
-     * @param window the window to draw the bitmap to
+     * @param destination the window to draw the bitmap to
      * @param bmp the bitmap which will be drawn to the screen
      * @param x     the x location which represents where the bitmap
      *              will be drawn
@@ -136,7 +136,7 @@ namespace splashkit_lib
      *
      * @attribute class   window
      * @attribute method  draw
-     * @attribute self    bmp
+     * @attribute self    destination
      * @attribute suffix  with_options
      */
     void draw_bitmap_on_window(window destination, bitmap bmp, float x, float y, drawing_options opts);
@@ -145,7 +145,7 @@ namespace splashkit_lib
      * Draws the bitmap supplied into `bmp` to the given bitmap.
      * at `x` and `y`.
      *
-     * @param bitmap the bitmap to draw the bitmap to
+     * @param destination the bitmap to draw the bitmap to
      * @param bmp the bitmap which will be drawn to the screen
      * @param x   the x location which represents where the bitmap
      *            will be drawn
@@ -162,7 +162,7 @@ namespace splashkit_lib
      * Draws the bitmap supplied into `bmp` to the given bitmap.
      * with extra drawing options supplied in `opts` at `x` and `y`.
      *
-     * @param bitmap the bitmap to draw the bitmap to
+     * @param destination the bitmap to draw the bitmap to
      * @param bmp the bitmap which will be drawn to the screen
      * @param x     the x location which represents where the bitmap
      *              will be drawn

--- a/coresdk/src/coresdk/images.h
+++ b/coresdk/src/coresdk/images.h
@@ -105,6 +105,80 @@ namespace splashkit_lib
     void draw_bitmap(bitmap bmp, float x, float y, drawing_options opts);
 
     /**
+     * Draws the bitmap supplied into `bmp` to the given window.
+     * at `x` and `y`.
+     *
+     * @param window the window to draw the bitmap to
+     * @param bmp the bitmap which will be drawn to the screen
+     * @param x   the x location which represents where the bitmap
+     *            will be drawn
+     * @param y   the y location which represents where the bitmap
+     *            will be drawn
+     *
+     * @attribute class   window
+     * @attribute method  draw
+     * @attribute self    bmp
+     */
+    void draw_bitmap_on_window(window destination, bitmap bmp, float x, float y);
+
+    /**
+     * Draws the bitmap supplied into `bmp` to the given window.
+     * with extra drawing options supplied in `opts` at `x` and `y`.
+     *
+     * @param window the window to draw the bitmap to
+     * @param bmp the bitmap which will be drawn to the screen
+     * @param x     the x location which represents where the bitmap
+     *              will be drawn
+     * @param y     the y location which represents where the bitmap
+     *              will be drawn
+     * @param opts  the `drawing_options` which provide extra information
+     *              for how to draw the `bitmap`
+     *
+     * @attribute class   window
+     * @attribute method  draw
+     * @attribute self    bmp
+     * @attribute suffix  with_options
+     */
+    void draw_bitmap_on_window(window destination, bitmap bmp, float x, float y, drawing_options opts);
+
+    /**
+     * Draws the bitmap supplied into `bmp` to the given bitmap.
+     * at `x` and `y`.
+     *
+     * @param bitmap the bitmap to draw the bitmap to
+     * @param bmp the bitmap which will be drawn to the screen
+     * @param x   the x location which represents where the bitmap
+     *            will be drawn
+     * @param y   the y location which represents where the bitmap
+     *            will be drawn
+     *
+     * @attribute class   bitmap
+     * @attribute method  draw
+     * @attribute self    bmp
+     */
+    void draw_bitmap_on_bitmap(bitmap destination, bitmap bmp, float x, float y);
+
+    /**
+     * Draws the bitmap supplied into `bmp` to the given bitmap.
+     * with extra drawing options supplied in `opts` at `x` and `y`.
+     *
+     * @param bitmap the bitmap to draw the bitmap to
+     * @param bmp the bitmap which will be drawn to the screen
+     * @param x     the x location which represents where the bitmap
+     *              will be drawn
+     * @param y     the y location which represents where the bitmap
+     *              will be drawn
+     * @param opts  the `drawing_options` which provide extra information
+     *              for how to draw the `bitmap`
+     *
+     * @attribute class   bitmap
+     * @attribute method  draw
+     * @attribute self    bmp
+     * @attribute suffix  with_options
+     */
+    void draw_bitmap_on_bitmap(bitmap destination, bitmap bmp, float x, float y, drawing_options opts);
+
+    /**
      * Searches and draws a bitmap with name `name` to the current window.
      * with extra drawing options supplied in `opts` at `x` and `y`.
      *

--- a/coresdk/src/coresdk/images.h
+++ b/coresdk/src/coresdk/images.h
@@ -155,6 +155,7 @@ namespace splashkit_lib
      * @attribute class   bitmap
      * @attribute method  draw
      * @attribute self    bmp
+     * @attribute suffix  on_bitmap
      */
     void draw_bitmap_on_bitmap(bitmap destination, bitmap bmp, float x, float y);
 
@@ -174,7 +175,7 @@ namespace splashkit_lib
      * @attribute class   bitmap
      * @attribute method  draw
      * @attribute self    bmp
-     * @attribute suffix  with_options
+     * @attribute suffix  on_bitmap_with_options
      */
     void draw_bitmap_on_bitmap(bitmap destination, bitmap bmp, float x, float y, drawing_options opts);
 

--- a/coresdk/src/coresdk/line_drawing.cpp
+++ b/coresdk/src/coresdk/line_drawing.cpp
@@ -52,4 +52,64 @@ namespace splashkit_lib
     {
         draw_line(clr, l.start_point.x, l.start_point.y, l.end_point.x, l.end_point.y, opts);
     }
+    
+    void draw_line_on_window(window destination, color clr, float x1, float y1, float x2, float y2)
+    {
+        draw_line(clr, x1, y1, x2, y2, option_draw_to(destination));
+    }
+    
+    void draw_line_on_window(window destination, color clr, float x1, float y1, float x2, float y2, const drawing_options &opts)
+    {
+        draw_line(clr, x1, y1, x2, y2, option_draw_to(destination, opts));
+    }
+    
+    void draw_line_on_window(window destination, color clr, const point_2d &from_pt, const point_2d &to_pt)
+    {
+        draw_line(clr, from_pt, to_pt, option_draw_to(destination));
+    }
+    
+    void draw_line_on_window(window destination, color clr, const point_2d &from_pt, const point_2d &to_pt, const drawing_options &opts)
+    {
+        draw_line(clr, from_pt, to_pt, option_draw_to(destination, opts));
+    }
+    
+    void draw_line_on_window(window destination, color clr, const line &l)
+    {
+        draw_line(clr, l, option_draw_to(destination));
+    }
+    
+    void draw_line_on_window(window destination, color clr, const line &l, drawing_options opts)
+    {
+        draw_line(clr, l, option_draw_to(destination, opts));
+    }
+    
+    void draw_line_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2)
+    {
+        draw_line(clr, x1, y1, x2, y2, option_draw_to(destination));
+    }
+    
+    void draw_line_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2, const drawing_options &opts)
+    {
+        draw_line(clr, x1, y1, x2, y2, option_draw_to(destination, opts));
+    }
+    
+    void draw_line_on_bitmap(bitmap destination, color clr, const point_2d &from_pt, const point_2d &to_pt)
+    {
+        draw_line(clr, from_pt, to_pt, option_draw_to(destination));
+    }
+    
+    void draw_line_on_bitmap(bitmap destination, color clr, const point_2d &from_pt, const point_2d &to_pt, const drawing_options &opts)
+    {
+        draw_line(clr, from_pt, to_pt, option_draw_to(destination, opts));
+    }
+    
+    void draw_line_on_bitmap(bitmap destination, color clr, const line &l)
+    {
+        draw_line(clr, l, option_draw_to(destination));
+    }
+    
+    void draw_line_on_bitmap(bitmap destination, color clr, const line &l, drawing_options opts)
+    {
+        draw_line(clr, l, option_draw_to(destination, opts));
+    }
 }

--- a/coresdk/src/coresdk/line_drawing.h
+++ b/coresdk/src/coresdk/line_drawing.h
@@ -88,5 +88,172 @@ namespace splashkit_lib
      * @attribute suffix  record_with_options
      */
     void draw_line(color clr, const line &l, drawing_options opts);
+    
+    /**
+     * Draw a line from one point to another on the given window.
+     *
+     * @param destination  The destination bitmap
+     * @param clr The color of the line
+     * @param x1  The distance from the left of the window/bitmap to the first
+     *            point
+     * @param y1  The distance from the top of the window/bitmap to the first
+     *            point
+     * @param x2  The distance from the left of the window/bitmap to the second
+     *            point
+     * @param y2  The distance from the top of the window/bitmap to the second
+     *            point
+     */
+    void draw_line_on_window(window destination, color clr, float x1, float y1, float x2, float y2);
+    
+    /**
+     * Draw a line from one point to another
+     *
+     * @param destination  The destination bitmap
+     * @param clr The color of the line
+     * @param x1  The distance from the left of the window/bitmap to the first
+     *            point
+     * @param y1  The distance from the top of the window/bitmap to the first
+     *            point
+     * @param x2  The distance from the left of the window/bitmap to the second
+     *            point
+     * @param y2  The distance from the top of the window/bitmap to the second
+     *            point
+     * @param opts The drawing options
+     *
+     * @attribute suffix  with_options
+     */
+    void draw_line_on_window(window destination, color clr, float x1, float y1, float x2, float y2, const drawing_options &opts);
+    
+    /**
+     * Draw a line from one point to another on the given window.
+     *
+     * @param destination  The destination bitmap
+     * @param clr       The color of the line
+     * @param from_pt   The start of the line
+     * @param to_pt     The end of the line
+     *
+     * @attribute suffix  point_to_point
+     */
+    void draw_line_on_window(window destination, color clr, const point_2d &from_pt, const point_2d &to_pt);
+    
+    /**
+     * Draw a line from one point to another on the given window.
+     *
+     * @param destination  The destination bitmap
+     * @param clr       The color of the line
+     * @param from_pt   The start of the line
+     * @param to_pt     The end of the line
+     * @param opts The drawing options
+     *
+     * @attribute suffix  point_to_point_with_options
+     */
+    void draw_line_on_window(window destination, color clr, const point_2d &from_pt, const point_2d &to_pt, const drawing_options &opts);
+    
+    /**
+     * Draws a line onto the given window.
+     *
+     * @param destination  The destination bitmap
+     * @param clr The color of the line
+     * @param l   The line's details
+     *
+     * @attribute suffix  record
+     */
+    void draw_line_on_window(window destination, color clr, const line &l);
+    
+    /**
+     * Draws a line on the given window.
+     *
+     * @param destination  The destination bitmap
+     * @param clr The color of the line
+     * @param l   The line's details
+     * @param opts The drawing options
+     *
+     * @attribute suffix  record_with_options
+     */
+    void draw_line_on_window(window destination, color clr, const line &l, drawing_options opts);
+    
+    /**
+     * Draw a line from one point to another on the given bitmap.
+     *
+     * @param destination  The destination bitmap
+     * @param clr The color of the line
+     * @param x1  The distance from the left of the bitmap/bitmap to the first
+     *            point
+     * @param y1  The distance from the top of the bitmap/bitmap to the first
+     *            point
+     * @param x2  The distance from the left of the bitmap/bitmap to the second
+     *            point
+     * @param y2  The distance from the top of the bitmap/bitmap to the second
+     *            point
+     */
+    void draw_line_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2);
+    
+    /**
+     * Draw a line from one point to another
+     *
+     * @param destination  The destination bitmap
+     * @param clr The color of the line
+     * @param x1  The distance from the left of the bitmap/bitmap to the first
+     *            point
+     * @param y1  The distance from the top of the bitmap/bitmap to the first
+     *            point
+     * @param x2  The distance from the left of the bitmap/bitmap to the second
+     *            point
+     * @param y2  The distance from the top of the bitmap/bitmap to the second
+     *            point
+     * @param opts The drawing options
+     *
+     * @attribute suffix  with_options
+     */
+    void draw_line_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2, const drawing_options &opts);
+    
+    /**
+     * Draw a line from one point to another on the given bitmap.
+     *
+     * @param destination  The destination bitmap
+     * @param clr       The color of the line
+     * @param from_pt   The start of the line
+     * @param to_pt     The end of the line
+     *
+     * @attribute suffix  point_to_point
+     */
+    void draw_line_on_bitmap(bitmap destination, color clr, const point_2d &from_pt, const point_2d &to_pt);
+    
+    /**
+     * Draw a line from one point to another on the given bitmap.
+     *
+     * @param destination  The destination bitmap
+     * @param clr       The color of the line
+     * @param from_pt   The start of the line
+     * @param to_pt     The end of the line
+     * @param opts The drawing options
+     *
+     * @attribute suffix  point_to_point_with_options
+     */
+    void draw_line_on_bitmap(bitmap destination, color clr, const point_2d &from_pt, const point_2d &to_pt, const drawing_options &opts);
+    
+    /**
+     * Draws a line onto the given bitmap.
+     *
+     * @param destination  The destination bitmap
+     * @param clr The color of the line
+     * @param l   The line's details
+     *
+     * @attribute suffix  record
+     */
+    void draw_line_on_bitmap(bitmap destination, color clr, const line &l);
+    
+    /**
+     * Draws a line on the given bitmap.
+     *
+     * @param destination  The destination bitmap
+     * @param clr The color of the line
+     * @param l   The line's details
+     * @param opts The drawing options
+     *
+     * @attribute suffix  record_with_options
+     */
+    void draw_line_on_bitmap(bitmap destination, color clr, const line &l, drawing_options opts);
+
 }
 #endif /* line_drawing_h */

--- a/coresdk/src/coresdk/line_drawing.h
+++ b/coresdk/src/coresdk/line_drawing.h
@@ -102,6 +102,8 @@ namespace splashkit_lib
      *            point
      * @param y2  The distance from the top of the window/bitmap to the second
      *            point
+     *
+     * @attribute class   window
      */
     void draw_line_on_window(window destination, color clr, float x1, float y1, float x2, float y2);
     
@@ -120,6 +122,7 @@ namespace splashkit_lib
      *            point
      * @param opts The drawing options
      *
+     * @attribute class   window
      * @attribute suffix  with_options
      */
     void draw_line_on_window(window destination, color clr, float x1, float y1, float x2, float y2, const drawing_options &opts);
@@ -132,6 +135,7 @@ namespace splashkit_lib
      * @param from_pt   The start of the line
      * @param to_pt     The end of the line
      *
+     * @attribute class   window
      * @attribute suffix  point_to_point
      */
     void draw_line_on_window(window destination, color clr, const point_2d &from_pt, const point_2d &to_pt);
@@ -145,6 +149,7 @@ namespace splashkit_lib
      * @param to_pt     The end of the line
      * @param opts The drawing options
      *
+     * @attribute class   window
      * @attribute suffix  point_to_point_with_options
      */
     void draw_line_on_window(window destination, color clr, const point_2d &from_pt, const point_2d &to_pt, const drawing_options &opts);
@@ -156,6 +161,7 @@ namespace splashkit_lib
      * @param clr The color of the line
      * @param l   The line's details
      *
+     * @attribute class   window
      * @attribute suffix  record
      */
     void draw_line_on_window(window destination, color clr, const line &l);
@@ -168,6 +174,7 @@ namespace splashkit_lib
      * @param l   The line's details
      * @param opts The drawing options
      *
+     * @attribute class   window
      * @attribute suffix  record_with_options
      */
     void draw_line_on_window(window destination, color clr, const line &l, drawing_options opts);
@@ -185,6 +192,8 @@ namespace splashkit_lib
      *            point
      * @param y2  The distance from the top of the bitmap/bitmap to the second
      *            point
+     *
+     * @attribute class   bitmap
      */
     void draw_line_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2);
     
@@ -203,6 +212,7 @@ namespace splashkit_lib
      *            point
      * @param opts The drawing options
      *
+     * @attribute class   bitmap
      * @attribute suffix  with_options
      */
     void draw_line_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2, const drawing_options &opts);
@@ -215,6 +225,7 @@ namespace splashkit_lib
      * @param from_pt   The start of the line
      * @param to_pt     The end of the line
      *
+     * @attribute class   bitmap
      * @attribute suffix  point_to_point
      */
     void draw_line_on_bitmap(bitmap destination, color clr, const point_2d &from_pt, const point_2d &to_pt);
@@ -228,6 +239,7 @@ namespace splashkit_lib
      * @param to_pt     The end of the line
      * @param opts The drawing options
      *
+     * @attribute class   bitmap
      * @attribute suffix  point_to_point_with_options
      */
     void draw_line_on_bitmap(bitmap destination, color clr, const point_2d &from_pt, const point_2d &to_pt, const drawing_options &opts);
@@ -239,6 +251,7 @@ namespace splashkit_lib
      * @param clr The color of the line
      * @param l   The line's details
      *
+     * @attribute class   bitmap
      * @attribute suffix  record
      */
     void draw_line_on_bitmap(bitmap destination, color clr, const line &l);
@@ -251,6 +264,7 @@ namespace splashkit_lib
      * @param l   The line's details
      * @param opts The drawing options
      *
+     * @attribute class   bitmap
      * @attribute suffix  record_with_options
      */
     void draw_line_on_bitmap(bitmap destination, color clr, const line &l, drawing_options opts);

--- a/coresdk/src/coresdk/point_drawing.cpp
+++ b/coresdk/src/coresdk/point_drawing.cpp
@@ -83,4 +83,54 @@ namespace splashkit_lib
     {
         return get_pixel(current_window(), pt.x, pt.y);
     }
+    
+    void draw_pixel_on_window(window destination, color clr, float x, float y)
+    {
+        draw_pixel(clr, x, y, option_draw_to(destination));
+    }
+    
+    void draw_pixel_on_window(window destination, color clr, float x, float y, drawing_options opts)
+    {
+        draw_pixel(clr, x, y, option_draw_to(destination, opts));
+    }
+    
+    void draw_pixel_on_window(window destination, color clr, const point_2d &pt)
+    {
+        draw_pixel(clr, pt, option_draw_to(destination));
+    }
+    
+    void draw_pixel_on_window(window destination, color clr, const point_2d &pt, drawing_options opts)
+    {
+        draw_pixel(clr, pt, option_draw_to(destination, opts));
+    }
+    
+    void draw_pixel_on_bitmap(bitmap destination, color clr, float x, float y)
+    {
+        draw_pixel(clr, x, y, option_draw_to(destination));
+    }
+    
+    void draw_pixel_on_bitmap(bitmap destination, color clr, float x, float y, drawing_options opts)
+    {
+        draw_pixel(clr, x, y, option_draw_to(destination, opts));
+    }
+    
+    void draw_pixel_on_bitmap(bitmap destination, color clr, const point_2d &pt)
+    {
+        draw_pixel(clr, pt, option_draw_to(destination));
+    }
+    
+    void draw_pixel_on_bitmap(bitmap destination, color clr, const point_2d &pt, drawing_options opts)
+    {
+        draw_pixel(clr, pt, option_draw_to(destination, opts));
+    }
+    
+    color get_pixel_from_window(window destination, float x, float y)
+    {
+        return get_pixel(destination, x, y);
+    }
+    
+    color get_pixel_from_window(window destination, const point_2d &pt)
+    {
+        return get_pixel(destination, pt.x, pt.y);
+    }
 }

--- a/coresdk/src/coresdk/point_drawing.h
+++ b/coresdk/src/coresdk/point_drawing.h
@@ -134,6 +134,7 @@ namespace splashkit_lib
     /**
      * Draws an individual pixel to the given window.
      *
+     * @param destination the window to draw the pixel on
      * @param clr The color of the pixel
      * @param x   The distance from the left edge of the window to the
      *            pixel
@@ -147,11 +148,13 @@ namespace splashkit_lib
     /**
      * Draws an individual pixel to the given window with the given drawing options.
      *
+     * @param destination The window to draw the pixel on
      * @param clr The color of the pixel
      * @param x   The distance from the left edge of the window to the
      *            pixel
      * @param y   The distance from the top edge of the window to the
      *            pixel
+     * @param opts The drawing options
      *
      * @attribute class  window
      */
@@ -160,6 +163,7 @@ namespace splashkit_lib
     /**
      * Draws an individual pixel to the given window.
      *
+     * @param destination The window to draw the pixel on
      * @param clr The color of the pixel
      * @param pt  The location of the pixel to draw
      *
@@ -171,8 +175,10 @@ namespace splashkit_lib
     /**
      * Draws an individual pixel to the given window with the given drawing options.
      *
+     * @param destination The window to draw the pixel on
      * @param clr The color of the pixel
      * @param pt  The location of the pixel to draw
+     * @param opts The drawing options
      *
      * @attribute class  window
      * @attribute suffix  at_point
@@ -183,6 +189,7 @@ namespace splashkit_lib
      * Returns the color of the pixel at the x,y location on the given
      * window.
      *
+     * @param destination The window to draw the pixel on
      * @param  x   The distance from the left edge of the window to the pixel
      *             to read
      * @param  y   The distance from the top of the window to the pixel to read
@@ -196,6 +203,7 @@ namespace splashkit_lib
      * Returns the color of the pixel at the x,y location on the given
      * window.
      *
+     * @param destination The window to draw the pixel on
      * @param  pt  The position of the pixel
      * @return     The color of the pixel at the supplied location
      *
@@ -206,6 +214,7 @@ namespace splashkit_lib
     /**
      * Draws an individual pixel to the given bitmap.
      *
+     * @param destination the bitmap to draw the pixel on
      * @param clr The color of the pixel
      * @param x   The distance from the left edge of the bitmap to the
      *            pixel
@@ -219,11 +228,13 @@ namespace splashkit_lib
     /**
      * Draws an individual pixel to the given bitmap with the given drawing options.
      *
+     * @param destination the bitmap to draw the pixel on
      * @param clr The color of the pixel
      * @param x   The distance from the left edge of the bitmap to the
      *            pixel
      * @param y   The distance from the top edge of the bitmap to the
      *            pixel
+     * @param opts The drawing options
      *
      * @attribute class  bitmap
      */
@@ -232,6 +243,7 @@ namespace splashkit_lib
     /**
      * Draws an individual pixel to the given bitmap.
      *
+     * @param destination the bitmap to draw the pixel on
      * @param clr The color of the pixel
      * @param pt  The location of the pixel to draw
      *
@@ -243,8 +255,10 @@ namespace splashkit_lib
     /**
      * Draws an individual pixel to the given bitmap with the given drawing options.
      *
+     * @param destination the bitmap to draw the pixel on
      * @param clr The color of the pixel
      * @param pt  The location of the pixel to draw
+     * @param opts The drawing options
      *
      * @attribute class  bitmap
      * @attribute suffix  at_point

--- a/coresdk/src/coresdk/point_drawing.h
+++ b/coresdk/src/coresdk/point_drawing.h
@@ -157,6 +157,7 @@ namespace splashkit_lib
      * @param opts The drawing options
      *
      * @attribute class  window
+     * @attribute suffix  with_options
      */
     void draw_pixel_on_window(window destination, color clr, float x, float y, drawing_options opts);
     
@@ -181,7 +182,7 @@ namespace splashkit_lib
      * @param opts The drawing options
      *
      * @attribute class  window
-     * @attribute suffix  at_point
+     * @attribute suffix  at_point_with_options
      */
     void draw_pixel_on_window(window destination, color clr, const point_2d &pt, drawing_options opts);
     
@@ -237,6 +238,7 @@ namespace splashkit_lib
      * @param opts The drawing options
      *
      * @attribute class  bitmap
+     * @attribute suffix  with_options
      */
     void draw_pixel_on_bitmap(bitmap destination, color clr, float x, float y, drawing_options opts);
     
@@ -261,7 +263,7 @@ namespace splashkit_lib
      * @param opts The drawing options
      *
      * @attribute class  bitmap
-     * @attribute suffix  at_point
+     * @attribute suffix  at_point_with_options
      */
     void draw_pixel_on_bitmap(bitmap destination, color clr, const point_2d &pt, drawing_options opts);
 }

--- a/coresdk/src/coresdk/point_drawing.h
+++ b/coresdk/src/coresdk/point_drawing.h
@@ -197,6 +197,7 @@ namespace splashkit_lib
      * @return     The color of the pixel at the supplied location
      *
      * @attribute class  window
+     * @attribute suffix  from_window
      */
     color get_pixel_from_window(window destination, float x, float y);
     
@@ -208,7 +209,7 @@ namespace splashkit_lib
      * @param  pt  The position of the pixel
      * @return     The color of the pixel at the supplied location
      *
-     * @attribute suffix  at_point
+     * @attribute suffix  at_point_from_window
      */
     color get_pixel_from_window(window destination, const point_2d &pt);
     

--- a/coresdk/src/coresdk/point_drawing.h
+++ b/coresdk/src/coresdk/point_drawing.h
@@ -130,5 +130,125 @@ namespace splashkit_lib
      * @attribute suffix  at_point
      */
     color get_pixel(const point_2d &pt);
+    
+    /**
+     * Draws an individual pixel to the given window.
+     *
+     * @param clr The color of the pixel
+     * @param x   The distance from the left edge of the window to the
+     *            pixel
+     * @param y   The distance from the top edge of the window to the
+     *            pixel
+     *
+     * @attribute class  window
+     */
+    void draw_pixel_on_window(window destination, color clr, float x, float y);
+    
+    /**
+     * Draws an individual pixel to the given window with the given drawing options.
+     *
+     * @param clr The color of the pixel
+     * @param x   The distance from the left edge of the window to the
+     *            pixel
+     * @param y   The distance from the top edge of the window to the
+     *            pixel
+     *
+     * @attribute class  window
+     */
+    void draw_pixel_on_window(window destination, color clr, float x, float y, drawing_options opts);
+    
+    /**
+     * Draws an individual pixel to the given window.
+     *
+     * @param clr The color of the pixel
+     * @param pt  The location of the pixel to draw
+     *
+     * @attribute class  window
+     * @attribute suffix  at_point
+     */
+    void draw_pixel_on_window(window destination, color clr, const point_2d &pt);
+    
+    /**
+     * Draws an individual pixel to the given window with the given drawing options.
+     *
+     * @param clr The color of the pixel
+     * @param pt  The location of the pixel to draw
+     *
+     * @attribute class  window
+     * @attribute suffix  at_point
+     */
+    void draw_pixel_on_window(window destination, color clr, const point_2d &pt, drawing_options opts);
+    
+    /**
+     * Returns the color of the pixel at the x,y location on the given
+     * window.
+     *
+     * @param  x   The distance from the left edge of the window to the pixel
+     *             to read
+     * @param  y   The distance from the top of the window to the pixel to read
+     * @return     The color of the pixel at the supplied location
+     *
+     * @attribute class  window
+     */
+    color get_pixel_from_window(window destination, float x, float y);
+    
+    /**
+     * Returns the color of the pixel at the x,y location on the given
+     * window.
+     *
+     * @param  pt  The position of the pixel
+     * @return     The color of the pixel at the supplied location
+     *
+     * @attribute suffix  at_point
+     */
+    color get_pixel_from_window(window destination, const point_2d &pt);
+    
+    /**
+     * Draws an individual pixel to the given bitmap.
+     *
+     * @param clr The color of the pixel
+     * @param x   The distance from the left edge of the bitmap to the
+     *            pixel
+     * @param y   The distance from the top edge of the bitmap to the
+     *            pixel
+     *
+     * @attribute class  bitmap
+     */
+    void draw_pixel_on_bitmap(bitmap destination, color clr, float x, float y);
+    
+    /**
+     * Draws an individual pixel to the given bitmap with the given drawing options.
+     *
+     * @param clr The color of the pixel
+     * @param x   The distance from the left edge of the bitmap to the
+     *            pixel
+     * @param y   The distance from the top edge of the bitmap to the
+     *            pixel
+     *
+     * @attribute class  bitmap
+     */
+    void draw_pixel_on_bitmap(bitmap destination, color clr, float x, float y, drawing_options opts);
+    
+    /**
+     * Draws an individual pixel to the given bitmap.
+     *
+     * @param clr The color of the pixel
+     * @param pt  The location of the pixel to draw
+     *
+     * @attribute class  bitmap
+     * @attribute suffix  at_point
+     */
+    void draw_pixel_on_bitmap(bitmap destination, color clr, const point_2d &pt);
+    
+    /**
+     * Draws an individual pixel to the given bitmap with the given drawing options.
+     *
+     * @param clr The color of the pixel
+     * @param pt  The location of the pixel to draw
+     *
+     * @attribute class  bitmap
+     * @attribute suffix  at_point
+     */
+    void draw_pixel_on_bitmap(bitmap destination, color clr, const point_2d &pt, drawing_options opts);
 }
 #endif /* point_drawing_h */

--- a/coresdk/src/coresdk/rectangle_drawing.cpp
+++ b/coresdk/src/coresdk/rectangle_drawing.cpp
@@ -211,62 +211,62 @@ namespace splashkit_lib
     {
         fill_quad(clr, q, option_draw_to(destination, opts));
     }
-    
+
     void draw_rectangle_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height, drawing_options opts)
     {
         draw_rectangle(clr, x, y, width, height, option_draw_to(destination, opts));
     }
-    
+
     void draw_rectangle_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height)
     {
         draw_rectangle(clr, x, y, width, height, option_draw_to(destination));
     }
-    
+
     void draw_rectangle_on_bitmap(bitmap destination, color clr, const rectangle &rect, const drawing_options &opts)
     {
         draw_rectangle(clr, rect.x, rect.y, rect.width, rect.height, option_draw_to(destination, opts));
     }
-    
+
     void draw_rectangle_on_bitmap(bitmap destination, color clr, const rectangle &rect)
     {
         draw_rectangle(clr, rect.x, rect.y, rect.width, rect.height, option_draw_to(destination));
     }
-    
+
     void fill_rectangle_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height, const drawing_options &opts)
     {
         fill_rectangle(clr, x, y, width, height, option_draw_to(destination, opts));
     }
-    
+
     void fill_rectangle_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height)
     {
         fill_rectangle(clr, x, y, width, height, option_draw_to(destination));
     }
-    
+
     void fill_rectangle_on_bitmap(bitmap destination, color clr, const rectangle &rect, const drawing_options &opts)
     {
         fill_rectangle(clr, rect.x, rect.y, rect.width, rect.height, option_draw_to(destination, opts));
     }
-    
+
     void fill_rectangle_on_bitmap(bitmap destination, color clr, const rectangle &rect)
     {
         fill_rectangle(clr, rect.x, rect.y, rect.width, rect.height, option_draw_to(destination));
     }
-    
+
     void draw_quad_on_bitmap(bitmap destination, color clr, const quad &q)
     {
         draw_quad(clr, q, option_draw_to(destination));
     }
-    
+
     void draw_quad_on_bitmap(bitmap destination, color clr, const quad &q, const drawing_options &opts)
     {
         draw_quad(clr, q, option_draw_to(destination, opts));
     }
-    
+
     void fill_quad_on_bitmap(bitmap destination, color clr, const quad &q)
     {
         fill_quad(clr, q, option_draw_to(destination));
     }
-    
+
     void fill_quad_on_bitmap(bitmap destination, color clr, const quad &q, const drawing_options &opts)
     {
         fill_quad(clr, q, option_draw_to(destination, opts));

--- a/coresdk/src/coresdk/rectangle_drawing.cpp
+++ b/coresdk/src/coresdk/rectangle_drawing.cpp
@@ -211,4 +211,64 @@ namespace splashkit_lib
     {
         fill_quad(clr, q, option_draw_to(destination, opts));
     }
+    
+    void draw_rectangle_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height, drawing_options opts)
+    {
+        draw_rectangle(clr, x, y, width, height, option_draw_to(destination, opts));
+    }
+    
+    void draw_rectangle_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height)
+    {
+        draw_rectangle(clr, x, y, width, height, option_draw_to(destination));
+    }
+    
+    void draw_rectangle_on_bitmap(bitmap destination, color clr, const rectangle &rect, const drawing_options &opts)
+    {
+        draw_rectangle(clr, rect.x, rect.y, rect.width, rect.height, option_draw_to(destination, opts));
+    }
+    
+    void draw_rectangle_on_bitmap(bitmap destination, color clr, const rectangle &rect)
+    {
+        draw_rectangle(clr, rect.x, rect.y, rect.width, rect.height, option_draw_to(destination));
+    }
+    
+    void fill_rectangle_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height, const drawing_options &opts)
+    {
+        fill_rectangle(clr, x, y, width, height, option_draw_to(destination, opts));
+    }
+    
+    void fill_rectangle_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height)
+    {
+        fill_rectangle(clr, x, y, width, height, option_draw_to(destination));
+    }
+    
+    void fill_rectangle_on_bitmap(bitmap destination, color clr, const rectangle &rect, const drawing_options &opts)
+    {
+        fill_rectangle(clr, rect.x, rect.y, rect.width, rect.height, option_draw_to(destination, opts));
+    }
+    
+    void fill_rectangle_on_bitmap(bitmap destination, color clr, const rectangle &rect)
+    {
+        fill_rectangle(clr, rect.x, rect.y, rect.width, rect.height, option_draw_to(destination));
+    }
+    
+    void draw_quad_on_bitmap(bitmap destination, color clr, const quad &q)
+    {
+        draw_quad(clr, q, option_draw_to(destination));
+    }
+    
+    void draw_quad_on_bitmap(bitmap destination, color clr, const quad &q, const drawing_options &opts)
+    {
+        draw_quad(clr, q, option_draw_to(destination, opts));
+    }
+    
+    void fill_quad_on_bitmap(bitmap destination, color clr, const quad &q)
+    {
+        fill_quad(clr, q, option_draw_to(destination));
+    }
+    
+    void fill_quad_on_bitmap(bitmap destination, color clr, const quad &q, const drawing_options &opts)
+    {
+        fill_quad(clr, q, option_draw_to(destination, opts));
+    }
 }

--- a/coresdk/src/coresdk/rectangle_drawing.cpp
+++ b/coresdk/src/coresdk/rectangle_drawing.cpp
@@ -132,13 +132,13 @@ namespace splashkit_lib
     {
         fill_quad(clr, q, option_defaults());
     }
-    
+
     void fill_quad(color clr, const quad &q, const drawing_options &opts)
     {
         sk_drawing_surface *surface;
-        
+
         surface = to_surface_ptr(opts.dest);
-        
+
         if (surface)
         {
             float pts[8];
@@ -151,5 +151,64 @@ namespace splashkit_lib
             sk_fill_rect(surface, clr, pts, 8);
         }
     }
-    
+
+    void draw_rectangle_on_window(window destination, color clr, float x, float y, float width, float height, drawing_options opts)
+    {
+        draw_rectangle(clr, x, y, width, height, option_draw_to(destination, opts));
+    }
+
+    void draw_rectangle_on_window(window destination, color clr, float x, float y, float width, float height)
+    {
+        draw_rectangle(clr, x, y, width, height, option_draw_to(destination));
+    }
+
+    void draw_rectangle_on_window(window destination, color clr, const rectangle &rect, const drawing_options &opts)
+    {
+        draw_rectangle(clr, rect.x, rect.y, rect.width, rect.height, option_draw_to(destination, opts));
+    }
+
+    void draw_rectangle_on_window(window destination, color clr, const rectangle &rect)
+    {
+        draw_rectangle(clr, rect.x, rect.y, rect.width, rect.height, option_draw_to(destination));
+    }
+
+    void fill_rectangle_on_window(window destination, color clr, float x, float y, float width, float height, const drawing_options &opts)
+    {
+        fill_rectangle(clr, x, y, width, height, option_draw_to(destination, opts));
+    }
+
+    void fill_rectangle_on_window(window destination, color clr, float x, float y, float width, float height)
+    {
+        fill_rectangle(clr, x, y, width, height, option_draw_to(destination));
+    }
+
+    void fill_rectangle_on_window(window destination, color clr, const rectangle &rect, const drawing_options &opts)
+    {
+        fill_rectangle(clr, rect.x, rect.y, rect.width, rect.height, option_draw_to(destination, opts));
+    }
+
+    void fill_rectangle_on_window(window destination, color clr, const rectangle &rect)
+    {
+        fill_rectangle(clr, rect.x, rect.y, rect.width, rect.height, option_draw_to(destination));
+    }
+
+    void draw_quad_on_window(window destination, color clr, const quad &q)
+    {
+        draw_quad(clr, q, option_draw_to(destination));
+    }
+
+    void draw_quad_on_window(window destination, color clr, const quad &q, const drawing_options &opts)
+    {
+        draw_quad(clr, q, option_draw_to(destination, opts));
+    }
+
+    void fill_quad_on_window(window destination, color clr, const quad &q)
+    {
+        fill_quad(clr, q, option_draw_to(destination));
+    }
+
+    void fill_quad_on_window(window destination, color clr, const quad &q, const drawing_options &opts)
+    {
+        fill_quad(clr, q, option_draw_to(destination, opts));
+    }
 }

--- a/coresdk/src/coresdk/rectangle_drawing.h
+++ b/coresdk/src/coresdk/rectangle_drawing.h
@@ -150,6 +150,170 @@ namespace splashkit_lib
      * @attribute suffix  with_options
      */
     void fill_quad(color clr, const quad &q, const drawing_options &opts);
+    
+    /**
+     * Fills a rectangle on the supplied window, using the supplied drawing options.
+     *
+     * @param destination   The destination window
+     * @param clr     The color of the rectangle
+     * @param x       The distance from the left of the window/bitmap to the
+     *                rectangle
+     * @param y       The distance from the top of the window/bitmap to the
+     *                rectangle
+     * @param width   The width of the rectangle
+     * @param height  The height of the rectangle
+     * @param opts    The drawing options
+     *
+     * @attribute suffix  with_options
+     */
+    void fill_rectangle_on_window(window destination, color clr, float x, float y, float width, float height, const drawing_options &opts);
+    
+    /**
+     * Fills a rectangle on the supplied window to the current window.
+     *
+     * @param destination   The destination window
+     * @param clr     The color of the rectangle
+     * @param x       The distance from the left of the window/bitmap to the
+     *                rectangle
+     * @param y       The distance from the top of the window/bitmap to the
+     *                rectangle
+     * @param width   The width of the rectangle
+     * @param height  The height of the rectangle
+     */
+    void fill_rectangle_on_window(window destination, color clr, float x, float y, float width, float height);
+    
+    /**
+     * Fills a rectangle on the supplied window using the supplied drawing options.
+     *
+     * @param destination   The destination window
+     * @param clr     The color of the rectangle
+     * @param rect    The rectangle to draw
+     * @param opts    The drawing options
+     *
+     * @attribute suffix  record_with_options
+     */
+    void fill_rectangle_on_window(window destination, color clr, const rectangle &rect, const drawing_options &opts);
+    
+    /**
+     * Fill a rectangle on the supplied window onto the current window.
+     *
+     * @param destination   The destination window
+     * @param clr     The color of the rectangle
+     * @param rect    The rectangle to draw
+     *
+     * @attribute suffix  record
+     */
+    void fill_rectangle_on_window(window destination, color clr, const rectangle &rect);
+    
+    /**
+     * Draw a quad on the supplied window to the current window.
+     *
+     * @param destination   The destination window
+     * @param clr   The color for the quad
+     * @param q     The details of the quad
+     */
+    void draw_quad_on_window(window destination, color clr, const quad &q);
+    
+    /**
+     * Draw a quad on the supplied window using the supplied drawing options.
+     *
+     * @param destination   The destination window
+     * @param clr   The color for the quad
+     * @param q     The details of the quad
+     * @param opts  The drawing options
+     *
+     * @attribute suffix  with_options
+     */
+    void draw_quad_on_window(window destination, color clr, const quad &q, const drawing_options &opts);
+    
+    /**
+     * Fill a quad on the supplied window on the current window.
+     *
+     * @param destination   The destination window
+     * @param clr   The color for the quad
+     * @param q     The details of the quad
+     */
+    void fill_quad_on_window(window destination, color clr, const quad &q);
+    
+    /**
+     * Fill a quad on the supplied window using the supplied drawing options.
+     *
+     * @param destination   The destination window
+     * @param clr The color for the quad
+     * @param q   The details of the quad
+     * @param opts  The drawing options
+     *
+     * @attribute suffix  with_options
+     */
+    void fill_quad_on_window(window destination, color clr, const quad &q, const drawing_options &opts);
+    
+    
+    
+    /**
+     *  Draw a rectangle to the window using the supplied drawing options. The rectangle is centred on its x, y
+     *  coordinates, and has the provided width and height.
+     *
+     * @param destination   The destination window
+     * @param clr    The color of the rectangle
+     * @param x      The x location of the rectangle
+     * @param y      The y location of the rectangle
+     * @param width  The width of the rectangle
+     * @param height The height of the rectangle
+     * @param opts   Drawing options to configure the drawing operation
+     *
+     * @attribute suffix    with_options
+     * @attribute class     window
+     * @attribute method    draw_rectangle
+     */
+    void draw_rectangle_on_window(window destination, color clr, float x, float y, float width, float height, drawing_options opts);
 
+    /**
+     *  Draw a rectangle to the window using. The rectangle is centred on its x, y
+     *  coordinates, and has the provided width and height.
+     *
+     * @param destination   The destination window
+     * @param clr    The color of the rectangle
+     * @param x      The x location of the rectangle
+     * @param y      The y location of the rectangle
+     * @param width  The width of the rectangle
+     * @param height The height of the rectangle
+     *
+     * @attribute class     window
+     * @attribute method    draw_rectangle
+     */
+    void draw_rectangle_on_window(window destination, color clr, float x, float y, float width, float height);
+
+    /**
+     *  Draw a rectangle to the window using the supplied rect and drawing options. The rectangle is centred on its x, y
+     *  coordinates, and has the provided width and height.
+     *
+     * @param destination   The destination window
+     * @param clr    The color of the rectangle
+     * @param x      The x location of the rectangle
+     * @param y      The y location of the rectangle
+     * @param rect   the rectangle to be drawn to the window
+     * @param opts   Drawing options to configure the drawing operation
+     *
+     * @attribute suffix    record_with_options
+     * @attribute class     window
+     * @attribute method    draw_rectangle
+     */
+    void draw_rectangle_on_window(window destination, color clr, const rectangle &rect, const drawing_options &opts);
+
+    /**
+     *  Draw a rectangle to the window using the supplied rect. The rectangle is centred on its x, y
+     *  coordinates, and has the provided width and height.
+     *
+     * @param destination   The destination window
+     * @param clr    The color of the rectangle
+     * @param x      The x location of the rectangle
+     * @param y      The y location of the rectangle
+     * @param rect   the rectangle to be drawn to the window
+     *
+     * @attribute suffix    record_with_options
+     * @attribute class     window
+     * @attribute method    draw_rectangle
+     */
+    void draw_rectangle_on_window(window destination, color clr, const rectangle &rect);
 }
 #endif /* rectangle_drawing_hpp */

--- a/coresdk/src/coresdk/rectangle_drawing.h
+++ b/coresdk/src/coresdk/rectangle_drawing.h
@@ -53,7 +53,7 @@ namespace splashkit_lib
      */
     void draw_rectangle(color clr, const rectangle &rect, const drawing_options &opts);
 
-    /**
+    /**git stat
      * Draw a rectangle onto the current window.
      *
      * @param clr     The color of the rectangle
@@ -247,8 +247,6 @@ namespace splashkit_lib
      */
     void fill_quad_on_window(window destination, color clr, const quad &q, const drawing_options &opts);
     
-    
-    
     /**
      *  Draw a rectangle to the window using the supplied drawing options. The rectangle is centred on its x, y
      *  coordinates, and has the provided width and height.
@@ -315,5 +313,169 @@ namespace splashkit_lib
      * @attribute method    draw_rectangle
      */
     void draw_rectangle_on_window(window destination, color clr, const rectangle &rect);
+    
+    /**
+     * Fills a rectangle on the supplied bitmap, using the supplied drawing options.
+     *
+     * @param destination   The destination bitmap
+     * @param clr     The color of the rectangle
+     * @param x       The distance from the left of the bitmap/bitmap to the
+     *                rectangle
+     * @param y       The distance from the top of the bitmap/bitmap to the
+     *                rectangle
+     * @param width   The width of the rectangle
+     * @param height  The height of the rectangle
+     * @param opts    The drawing options
+     *
+     * @attribute suffix  with_options
+     */
+    void fill_rectangle_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height, const drawing_options &opts);
+    
+    /**
+     * Fills a rectangle on the supplied bitmap to the current bitmap.
+     *
+     * @param destination   The destination bitmap
+     * @param clr     The color of the rectangle
+     * @param x       The distance from the left of the bitmap/bitmap to the
+     *                rectangle
+     * @param y       The distance from the top of the bitmap/bitmap to the
+     *                rectangle
+     * @param width   The width of the rectangle
+     * @param height  The height of the rectangle
+     */
+    void fill_rectangle_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height);
+    
+    /**
+     * Fills a rectangle on the supplied bitmap using the supplied drawing options.
+     *
+     * @param destination   The destination bitmap
+     * @param clr     The color of the rectangle
+     * @param rect    The rectangle to draw
+     * @param opts    The drawing options
+     *
+     * @attribute suffix  record_with_options
+     */
+    void fill_rectangle_on_bitmap(bitmap destination, color clr, const rectangle &rect, const drawing_options &opts);
+    
+    /**
+     * Fill a rectangle on the supplied bitmap onto the current bitmap.
+     *
+     * @param destination   The destination bitmap
+     * @param clr     The color of the rectangle
+     * @param rect    The rectangle to draw
+     *
+     * @attribute suffix  record
+     */
+    void fill_rectangle_on_bitmap(bitmap destination, color clr, const rectangle &rect);
+    
+    /**
+     * Draw a quad on the supplied bitmap to the current bitmap.
+     *
+     * @param destination   The destination bitmap
+     * @param clr   The color for the quad
+     * @param q     The details of the quad
+     */
+    void draw_quad_on_bitmap(bitmap destination, color clr, const quad &q);
+    
+    /**
+     * Draw a quad on the supplied bitmap using the supplied drawing options.
+     *
+     * @param destination   The destination bitmap
+     * @param clr   The color for the quad
+     * @param q     The details of the quad
+     * @param opts  The drawing options
+     *
+     * @attribute suffix  with_options
+     */
+    void draw_quad_on_bitmap(bitmap destination, color clr, const quad &q, const drawing_options &opts);
+    
+    /**
+     * Fill a quad on the supplied bitmap on the current bitmap.
+     *
+     * @param destination   The destination bitmap
+     * @param clr   The color for the quad
+     * @param q     The details of the quad
+     */
+    void fill_quad_on_bitmap(bitmap destination, color clr, const quad &q);
+    
+    /**
+     * Fill a quad on the supplied bitmap using the supplied drawing options.
+     *
+     * @param destination   The destination bitmap
+     * @param clr The color for the quad
+     * @param q   The details of the quad
+     * @param opts  The drawing options
+     *
+     * @attribute suffix  with_options
+     */
+    void fill_quad_on_bitmap(bitmap destination, color clr, const quad &q, const drawing_options &opts);
+    
+    /**
+     *  Draw a rectangle to the bitmap using the supplied drawing options. The rectangle is centred on its x, y
+     *  coordinates, and has the provided width and height.
+     *
+     * @param destination   The destination bitmap
+     * @param clr    The color of the rectangle
+     * @param x      The x location of the rectangle
+     * @param y      The y location of the rectangle
+     * @param width  The width of the rectangle
+     * @param height The height of the rectangle
+     * @param opts   Drawing options to configure the drawing operation
+     *
+     * @attribute suffix    with_options
+     * @attribute class     bitmap
+     * @attribute method    draw_rectangle
+     */
+    void draw_rectangle_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height, drawing_options opts);
+    
+    /**
+     *  Draw a rectangle to the bitmap using. The rectangle is centred on its x, y
+     *  coordinates, and has the provided width and height.
+     *
+     * @param destination   The destination bitmap
+     * @param clr    The color of the rectangle
+     * @param x      The x location of the rectangle
+     * @param y      The y location of the rectangle
+     * @param width  The width of the rectangle
+     * @param height The height of the rectangle
+     *
+     * @attribute class     bitmap
+     * @attribute method    draw_rectangle
+     */
+    void draw_rectangle_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height);
+    
+    /**
+     *  Draw a rectangle to the bitmap using the supplied rect and drawing options. The rectangle is centred on its x, y
+     *  coordinates, and has the provided width and height.
+     *
+     * @param destination   The destination bitmap
+     * @param clr    The color of the rectangle
+     * @param x      The x location of the rectangle
+     * @param y      The y location of the rectangle
+     * @param rect   the rectangle to be drawn to the bitmap
+     * @param opts   Drawing options to configure the drawing operation
+     *
+     * @attribute suffix    record_with_options
+     * @attribute class     bitmap
+     * @attribute method    draw_rectangle
+     */
+    void draw_rectangle_on_bitmap(bitmap destination, color clr, const rectangle &rect, const drawing_options &opts);
+    
+    /**
+     *  Draw a rectangle to the bitmap using the supplied rect. The rectangle is centred on its x, y
+     *  coordinates, and has the provided width and height.
+     *
+     * @param destination   The destination bitmap
+     * @param clr    The color of the rectangle
+     * @param x      The x location of the rectangle
+     * @param y      The y location of the rectangle
+     * @param rect   the rectangle to be drawn to the bitmap
+     *
+     * @attribute suffix    record_with_options
+     * @attribute class     bitmap
+     * @attribute method    draw_rectangle
+     */
+    void draw_rectangle_on_bitmap(bitmap destination, color clr, const rectangle &rect);
+    
 }
 #endif /* rectangle_drawing_hpp */

--- a/coresdk/src/coresdk/rectangle_drawing.h
+++ b/coresdk/src/coresdk/rectangle_drawing.h
@@ -298,8 +298,6 @@ namespace splashkit_lib
      *
      * @param destination   The destination window
      * @param clr    The color of the rectangle
-     * @param x      The x location of the rectangle
-     * @param y      The y location of the rectangle
      * @param rect   the rectangle to be drawn to the window
      * @param opts   Drawing options to configure the drawing operation
      *
@@ -315,8 +313,6 @@ namespace splashkit_lib
      *
      * @param destination   The destination window
      * @param clr    The color of the rectangle
-     * @param x      The x location of the rectangle
-     * @param y      The y location of the rectangle
      * @param rect   the rectangle to be drawn to the window
      *
      * @attribute suffix    record_with_options
@@ -489,7 +485,7 @@ namespace splashkit_lib
      * @param clr    The color of the rectangle
      * @param rect   the rectangle to be drawn to the bitmap
      *
-     * @attribute suffix    record_with_options
+     * @attribute suffix    record
      * @attribute class     bitmap
      * @attribute method    draw_rectangle
      */

--- a/coresdk/src/coresdk/rectangle_drawing.h
+++ b/coresdk/src/coresdk/rectangle_drawing.h
@@ -472,8 +472,6 @@ namespace splashkit_lib
      *
      * @param destination   The destination bitmap
      * @param clr    The color of the rectangle
-     * @param x      The x location of the rectangle
-     * @param y      The y location of the rectangle
      * @param rect   the rectangle to be drawn to the bitmap
      * @param opts   Drawing options to configure the drawing operation
      *
@@ -489,8 +487,6 @@ namespace splashkit_lib
      *
      * @param destination   The destination bitmap
      * @param clr    The color of the rectangle
-     * @param x      The x location of the rectangle
-     * @param y      The y location of the rectangle
      * @param rect   the rectangle to be drawn to the bitmap
      *
      * @attribute suffix    record_with_options

--- a/coresdk/src/coresdk/rectangle_drawing.h
+++ b/coresdk/src/coresdk/rectangle_drawing.h
@@ -164,6 +164,7 @@ namespace splashkit_lib
      * @param height  The height of the rectangle
      * @param opts    The drawing options
      *
+     * @attribute class   window
      * @attribute suffix  with_options
      */
     void fill_rectangle_on_window(window destination, color clr, float x, float y, float width, float height, const drawing_options &opts);
@@ -179,6 +180,8 @@ namespace splashkit_lib
      *                rectangle
      * @param width   The width of the rectangle
      * @param height  The height of the rectangle
+     *
+     * @attribute class   window
      */
     void fill_rectangle_on_window(window destination, color clr, float x, float y, float width, float height);
     
@@ -190,6 +193,7 @@ namespace splashkit_lib
      * @param rect    The rectangle to draw
      * @param opts    The drawing options
      *
+     * @attribute class   window
      * @attribute suffix  record_with_options
      */
     void fill_rectangle_on_window(window destination, color clr, const rectangle &rect, const drawing_options &opts);
@@ -201,6 +205,7 @@ namespace splashkit_lib
      * @param clr     The color of the rectangle
      * @param rect    The rectangle to draw
      *
+     * @attribute class   window
      * @attribute suffix  record
      */
     void fill_rectangle_on_window(window destination, color clr, const rectangle &rect);
@@ -211,6 +216,8 @@ namespace splashkit_lib
      * @param destination   The destination window
      * @param clr   The color for the quad
      * @param q     The details of the quad
+     *
+     * @attribute class   window
      */
     void draw_quad_on_window(window destination, color clr, const quad &q);
     
@@ -222,6 +229,7 @@ namespace splashkit_lib
      * @param q     The details of the quad
      * @param opts  The drawing options
      *
+     * @attribute class   window
      * @attribute suffix  with_options
      */
     void draw_quad_on_window(window destination, color clr, const quad &q, const drawing_options &opts);
@@ -232,6 +240,8 @@ namespace splashkit_lib
      * @param destination   The destination window
      * @param clr   The color for the quad
      * @param q     The details of the quad
+     *
+     * @attribute class   window
      */
     void fill_quad_on_window(window destination, color clr, const quad &q);
     
@@ -243,6 +253,7 @@ namespace splashkit_lib
      * @param q   The details of the quad
      * @param opts  The drawing options
      *
+     * @attribute class   window
      * @attribute suffix  with_options
      */
     void fill_quad_on_window(window destination, color clr, const quad &q, const drawing_options &opts);
@@ -327,6 +338,7 @@ namespace splashkit_lib
      * @param height  The height of the rectangle
      * @param opts    The drawing options
      *
+     * @attribute class   bitmap
      * @attribute suffix  with_options
      */
     void fill_rectangle_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height, const drawing_options &opts);
@@ -342,6 +354,8 @@ namespace splashkit_lib
      *                rectangle
      * @param width   The width of the rectangle
      * @param height  The height of the rectangle
+     *
+     * @attribute class   bitmap
      */
     void fill_rectangle_on_bitmap(bitmap destination, color clr, float x, float y, float width, float height);
     
@@ -353,6 +367,7 @@ namespace splashkit_lib
      * @param rect    The rectangle to draw
      * @param opts    The drawing options
      *
+     * @attribute class   bitmap
      * @attribute suffix  record_with_options
      */
     void fill_rectangle_on_bitmap(bitmap destination, color clr, const rectangle &rect, const drawing_options &opts);
@@ -364,6 +379,7 @@ namespace splashkit_lib
      * @param clr     The color of the rectangle
      * @param rect    The rectangle to draw
      *
+     * @attribute class   bitmap
      * @attribute suffix  record
      */
     void fill_rectangle_on_bitmap(bitmap destination, color clr, const rectangle &rect);
@@ -374,6 +390,8 @@ namespace splashkit_lib
      * @param destination   The destination bitmap
      * @param clr   The color for the quad
      * @param q     The details of the quad
+     *
+     * @attribute class   bitmap
      */
     void draw_quad_on_bitmap(bitmap destination, color clr, const quad &q);
     
@@ -385,6 +403,7 @@ namespace splashkit_lib
      * @param q     The details of the quad
      * @param opts  The drawing options
      *
+     * @attribute class   bitmap
      * @attribute suffix  with_options
      */
     void draw_quad_on_bitmap(bitmap destination, color clr, const quad &q, const drawing_options &opts);
@@ -395,6 +414,8 @@ namespace splashkit_lib
      * @param destination   The destination bitmap
      * @param clr   The color for the quad
      * @param q     The details of the quad
+     *
+     * @attribute class   bitmap
      */
     void fill_quad_on_bitmap(bitmap destination, color clr, const quad &q);
     
@@ -406,6 +427,7 @@ namespace splashkit_lib
      * @param q   The details of the quad
      * @param opts  The drawing options
      *
+     * @attribute class   bitmap
      * @attribute suffix  with_options
      */
     void fill_quad_on_bitmap(bitmap destination, color clr, const quad &q, const drawing_options &opts);

--- a/coresdk/src/coresdk/rectangle_drawing.h
+++ b/coresdk/src/coresdk/rectangle_drawing.h
@@ -315,7 +315,7 @@ namespace splashkit_lib
      * @param clr    The color of the rectangle
      * @param rect   the rectangle to be drawn to the window
      *
-     * @attribute suffix    record_with_options
+     * @attribute suffix    record
      * @attribute class     window
      * @attribute method    draw_rectangle
      */

--- a/coresdk/src/coresdk/triangle_drawing.cpp
+++ b/coresdk/src/coresdk/triangle_drawing.cpp
@@ -96,4 +96,44 @@ namespace splashkit_lib
                       tri.points[2].x, tri.points[2].y,
                       option_defaults());
     }
+
+    void draw_triangle_on_window(window destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3, drawing_options opts)
+    {
+        draw_triangle(clr, x1, y1, x2, y2, x3, y3, option_draw_to(destination, opts));
+    }
+    
+    void draw_triangle_on_window(window destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3)
+    {
+        draw_triangle(clr, x1, y1, x2, y2, x3, y3, option_draw_to(destination));
+    }
+    
+    void draw_triangle_on_window(window destination, color clr, const triangle &tri, drawing_options opts)
+    {
+        draw_triangle(clr, tri, option_draw_to(destination, opts));
+    }
+    
+    void draw_triangle_on_window(window destination, color clr, const triangle &tri)
+    {
+        draw_triangle(clr, tri, option_draw_to(destination));
+    }
+    
+    void fill_triangle_on_window(window destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3, drawing_options opts)
+    {
+        fill_triangle(clr, x1, y1, x2, y2, x3, y3, option_draw_to(destination, opts));
+    }
+    
+    void fill_triangle_on_window(window destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3)
+    {
+        fill_triangle(clr, x1, y1, x2, y2, x3, y3, option_draw_to(destination));
+    }
+    
+    void fill_triangle_on_window(window destination, color clr, const triangle &tri, drawing_options opts)
+    {
+        fill_triangle(clr, tri, option_draw_to(destination, opts));
+    }
+    
+    void fill_triangle_on_window(window destination, color clr, const triangle &tri)
+    {
+        fill_triangle(clr, tri, option_draw_to(destination));
+    }
 }

--- a/coresdk/src/coresdk/triangle_drawing.cpp
+++ b/coresdk/src/coresdk/triangle_drawing.cpp
@@ -101,37 +101,37 @@ namespace splashkit_lib
     {
         draw_triangle(clr, x1, y1, x2, y2, x3, y3, option_draw_to(destination, opts));
     }
-    
+
     void draw_triangle_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3)
     {
         draw_triangle(clr, x1, y1, x2, y2, x3, y3, option_draw_to(destination));
     }
-    
+
     void draw_triangle_on_bitmap(bitmap destination, color clr, const triangle &tri, drawing_options opts)
     {
         draw_triangle(clr, tri, option_draw_to(destination, opts));
     }
-    
+
     void draw_triangle_on_bitmap(bitmap destination, color clr, const triangle &tri)
     {
         draw_triangle(clr, tri, option_draw_to(destination));
     }
-    
+
     void fill_triangle_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3, drawing_options opts)
     {
         fill_triangle(clr, x1, y1, x2, y2, x3, y3, option_draw_to(destination, opts));
     }
-    
+
     void fill_triangle_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3)
     {
         fill_triangle(clr, x1, y1, x2, y2, x3, y3, option_draw_to(destination));
     }
-    
+
     void fill_triangle_on_bitmap(bitmap destination, color clr, const triangle &tri, drawing_options opts)
     {
         fill_triangle(clr, tri, option_draw_to(destination, opts));
     }
-    
+
     void fill_triangle_on_bitmap(bitmap destination, color clr, const triangle &tri)
     {
         fill_triangle(clr, tri, option_draw_to(destination));

--- a/coresdk/src/coresdk/triangle_drawing.cpp
+++ b/coresdk/src/coresdk/triangle_drawing.cpp
@@ -97,42 +97,42 @@ namespace splashkit_lib
                       option_defaults());
     }
 
-    void draw_triangle_on_window(window destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3, drawing_options opts)
+    void draw_triangle_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3, drawing_options opts)
     {
         draw_triangle(clr, x1, y1, x2, y2, x3, y3, option_draw_to(destination, opts));
     }
     
-    void draw_triangle_on_window(window destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3)
+    void draw_triangle_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3)
     {
         draw_triangle(clr, x1, y1, x2, y2, x3, y3, option_draw_to(destination));
     }
     
-    void draw_triangle_on_window(window destination, color clr, const triangle &tri, drawing_options opts)
+    void draw_triangle_on_bitmap(bitmap destination, color clr, const triangle &tri, drawing_options opts)
     {
         draw_triangle(clr, tri, option_draw_to(destination, opts));
     }
     
-    void draw_triangle_on_window(window destination, color clr, const triangle &tri)
+    void draw_triangle_on_bitmap(bitmap destination, color clr, const triangle &tri)
     {
         draw_triangle(clr, tri, option_draw_to(destination));
     }
     
-    void fill_triangle_on_window(window destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3, drawing_options opts)
+    void fill_triangle_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3, drawing_options opts)
     {
         fill_triangle(clr, x1, y1, x2, y2, x3, y3, option_draw_to(destination, opts));
     }
     
-    void fill_triangle_on_window(window destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3)
+    void fill_triangle_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3)
     {
         fill_triangle(clr, x1, y1, x2, y2, x3, y3, option_draw_to(destination));
     }
     
-    void fill_triangle_on_window(window destination, color clr, const triangle &tri, drawing_options opts)
+    void fill_triangle_on_bitmap(bitmap destination, color clr, const triangle &tri, drawing_options opts)
     {
         fill_triangle(clr, tri, option_draw_to(destination, opts));
     }
     
-    void fill_triangle_on_window(window destination, color clr, const triangle &tri)
+    void fill_triangle_on_bitmap(bitmap destination, color clr, const triangle &tri)
     {
         fill_triangle(clr, tri, option_draw_to(destination));
     }

--- a/coresdk/src/coresdk/triangle_drawing.h
+++ b/coresdk/src/coresdk/triangle_drawing.h
@@ -137,11 +137,6 @@ namespace splashkit_lib
      */
     void fill_triangle(color clr, const triangle &tri);
     
-    
-    
-    
-    
-    
     /**
      * Draw a triangle to the given window, using the supplied drawing options.
      *
@@ -273,5 +268,138 @@ namespace splashkit_lib
      * @attribute suffix  record
      */
     void fill_triangle_on_window(window destination, color clr, const triangle &tri);
+    
+    /**
+     * Draw a triangle to the given bitmap, using the supplied drawing options.
+     *
+     * @param destination The bitmap which the triangle will be drawn on.
+     * @param clr  The color for the triangle
+     * @param x1   The distance from the left side of the bitmap/bitmap to the
+     *             first point of the triangle
+     * @param y1   The distance from the top of the bitmap/bitmap to the
+     *             first point of the triangle
+     * @param x2   The distance from the left side of the bitmap/bitmap to the
+     *             second point of the triangle
+     * @param y2   The distance from the top of the bitmap/bitmap to the
+     *             second point of the triangle
+     * @param x3   The distance from the left side of the bitmap/bitmap to the
+     *             third point of the triangle
+     * @param y3   The distance from the top of the bitmap/bitmap to the
+     *             third point of the triangle
+     * @param opts The drawing options
+     *
+     * @attribute suffix  with_options
+     */
+    void draw_triangle_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3, drawing_options opts);
+    
+    /**
+     * Draw a triangle to the given bitmap.
+     *
+     * @param destination The bitmap which the triangle will be drawn on.
+     * @param clr  The color for the triangle
+     * @param x1   The distance from the left side of the bitmap to the
+     *             first point of the triangle
+     * @param y1   The distance from the top of the bitmap to the
+     *             first point of the triangle
+     * @param x2   The distance from the left side of the bitmap to the
+     *             second point of the triangle
+     * @param y2   The distance from the top of the bitmap to the
+     *             second point of the triangle
+     * @param x3   The distance from the left side of the bitmap to the
+     *             third point of the triangle
+     * @param y3   The distance from the top of the bitmap to the
+     *             third point of the triangle
+     */
+    void draw_triangle_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3);
+    
+    /**
+     * Draw a triangle on a given bitmap, using the supplied drawing options.
+     *
+     * @param destination The bitmap which the triangle will be drawn on.
+     * @param clr  The color for the triangle
+     * @param tri  The triangles details
+     * @param opts The drawing options
+     *
+     * @attribute suffix  record_with_options
+     */
+    void draw_triangle_on_bitmap(bitmap destination, color clr, const triangle &tri, drawing_options opts);
+    
+    /**
+     * Draw a triangle on a given bitmap, using the supplied drawing options.
+     *
+     * @param destination The bitmap which the triangle will be drawn on.
+     * @param clr  The color for the triangle
+     * @param tri  The triangles details
+     *
+     * @attribute suffix  record
+     */
+    void draw_triangle_on_bitmap(bitmap destination, color clr, const triangle &tri);
+    
+    /**
+     * Fill a triangle on a given bitmap, using the supplied drawing options.
+     *
+     * @param destination The bitmap which the triangle will be drawn on.
+     * @param clr  The color for the triangle
+     * @param x1   The distance from the left side of the bitmap/bitmap to the
+     *             first point of the triangle
+     * @param y1   The distance from the top of the bitmap/bitmap to the
+     *             first point of the triangle
+     * @param x2   The distance from the left side of the bitmap/bitmap to the
+     *             second point of the triangle
+     * @param y2   The distance from the top of the bitmap/bitmap to the
+     *             second point of the triangle
+     * @param x3   The distance from the left side of the bitmap/bitmap to the
+     *             third point of the triangle
+     * @param y3   The distance from the top of the bitmap/bitmap to the
+     *             third point of the triangle
+     * @param opts The drawing options
+     *
+     * @attribute suffix  with_options
+     */
+    void fill_triangle_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3, drawing_options opts);
+    
+    /**
+     * Fill a triangle on a given bitmap
+     *
+     * @param destination The bitmap which the triangle will be drawn on.
+     * @param clr  The color for the triangle
+     * @param x1   The distance from the left side of the bitmap to the
+     *             first point of the triangle
+     * @param y1   The distance from the top of the bitmap to the
+     *             first point of the triangle
+     * @param x2   The distance from the left side of the bitmap to the
+     *             second point of the triangle
+     * @param y2   The distance from the top of the bitmap to the
+     *             second point of the triangle
+     * @param x3   The distance from the left side of the bitmap to the
+     *             third point of the triangle
+     * @param y3   The distance from the top of the bitmap to the
+     *             third point of the triangle
+     */
+    void fill_triangle_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3);
+    
+    /**
+     * Fill a triangle on a given bitmap, using given drawing options
+     *
+     * @param destination The bitmap which the triangle will be drawn on.
+     * @param clr  The color for the triangle
+     * @param tri  The triangles details
+     * @param opts The drawing options
+     *
+     * @attribute suffix  record_with_options
+     */
+    void fill_triangle_on_bitmap(bitmap destination, color clr, const triangle &tri, drawing_options opts);
+    
+    /**
+     * Fill a triangle on a given bitmap
+     *
+     * @param destination The bitmap which the triangle will be drawn on.
+     * @param clr  The color for the triangle
+     * @param tri  The triangles details
+     *
+     * @attribute suffix  record
+     */
+    void fill_triangle_on_bitmap(bitmap destination, color clr, const triangle &tri);
+
 }
 #endif /* triangle_drawing_hpp */

--- a/coresdk/src/coresdk/triangle_drawing.h
+++ b/coresdk/src/coresdk/triangle_drawing.h
@@ -156,6 +156,8 @@ namespace splashkit_lib
      *             third point of the triangle
      * @param opts The drawing options
      *
+     *
+     * @attribute class   window
      * @attribute suffix  with_options
      */
     void draw_triangle_on_window(window destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3, drawing_options opts);
@@ -177,6 +179,8 @@ namespace splashkit_lib
      *             third point of the triangle
      * @param y3   The distance from the top of the window to the
      *             third point of the triangle
+     *
+     * @attribute class   window
      */
     void draw_triangle_on_window(window destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3);
     
@@ -188,6 +192,7 @@ namespace splashkit_lib
      * @param tri  The triangles details
      * @param opts The drawing options
      *
+     * @attribute class   window
      * @attribute suffix  record_with_options
      */
     void draw_triangle_on_window(window destination, color clr, const triangle &tri, drawing_options opts);
@@ -199,6 +204,7 @@ namespace splashkit_lib
      * @param clr  The color for the triangle
      * @param tri  The triangles details
      *
+     * @attribute class   window
      * @attribute suffix  record
      */
     void draw_triangle_on_window(window destination, color clr, const triangle &tri);
@@ -222,6 +228,7 @@ namespace splashkit_lib
      *             third point of the triangle
      * @param opts The drawing options
      *
+     * @attribute class   window
      * @attribute suffix  with_options
      */
     void fill_triangle_on_window(window destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3, drawing_options opts);
@@ -243,6 +250,8 @@ namespace splashkit_lib
      *             third point of the triangle
      * @param y3   The distance from the top of the window to the
      *             third point of the triangle
+     *
+     * @attribute class   window
      */
     void fill_triangle_on_window(window destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3);
     
@@ -254,6 +263,7 @@ namespace splashkit_lib
      * @param tri  The triangles details
      * @param opts The drawing options
      *
+     * @attribute class   window
      * @attribute suffix  record_with_options
      */
     void fill_triangle_on_window(window destination, color clr, const triangle &tri, drawing_options opts);
@@ -265,6 +275,7 @@ namespace splashkit_lib
      * @param clr  The color for the triangle
      * @param tri  The triangles details
      *
+     * @attribute class   window
      * @attribute suffix  record
      */
     void fill_triangle_on_window(window destination, color clr, const triangle &tri);
@@ -288,6 +299,7 @@ namespace splashkit_lib
      *             third point of the triangle
      * @param opts The drawing options
      *
+     * @attribute class   bitmap
      * @attribute suffix  with_options
      */
     void draw_triangle_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3, drawing_options opts);
@@ -309,6 +321,8 @@ namespace splashkit_lib
      *             third point of the triangle
      * @param y3   The distance from the top of the bitmap to the
      *             third point of the triangle
+     *
+     * @attribute class   bitmap
      */
     void draw_triangle_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3);
     
@@ -320,6 +334,7 @@ namespace splashkit_lib
      * @param tri  The triangles details
      * @param opts The drawing options
      *
+     * @attribute class   bitmap
      * @attribute suffix  record_with_options
      */
     void draw_triangle_on_bitmap(bitmap destination, color clr, const triangle &tri, drawing_options opts);
@@ -331,6 +346,7 @@ namespace splashkit_lib
      * @param clr  The color for the triangle
      * @param tri  The triangles details
      *
+     * @attribute class   bitmap
      * @attribute suffix  record
      */
     void draw_triangle_on_bitmap(bitmap destination, color clr, const triangle &tri);
@@ -354,6 +370,7 @@ namespace splashkit_lib
      *             third point of the triangle
      * @param opts The drawing options
      *
+     * @attribute class   bitmap
      * @attribute suffix  with_options
      */
     void fill_triangle_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3, drawing_options opts);
@@ -375,6 +392,8 @@ namespace splashkit_lib
      *             third point of the triangle
      * @param y3   The distance from the top of the bitmap to the
      *             third point of the triangle
+     *
+     * @attribute class   bitmap
      */
     void fill_triangle_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3);
     
@@ -386,6 +405,7 @@ namespace splashkit_lib
      * @param tri  The triangles details
      * @param opts The drawing options
      *
+     * @attribute class   bitmap
      * @attribute suffix  record_with_options
      */
     void fill_triangle_on_bitmap(bitmap destination, color clr, const triangle &tri, drawing_options opts);
@@ -397,6 +417,7 @@ namespace splashkit_lib
      * @param clr  The color for the triangle
      * @param tri  The triangles details
      *
+     * @attribute class   bitmap
      * @attribute suffix  record
      */
     void fill_triangle_on_bitmap(bitmap destination, color clr, const triangle &tri);

--- a/coresdk/src/coresdk/triangle_drawing.h
+++ b/coresdk/src/coresdk/triangle_drawing.h
@@ -136,7 +136,7 @@ namespace splashkit_lib
      * @attribute suffix  record
      */
     void fill_triangle(color clr, const triangle &tri);
-    
+
     /**
      * Draw a triangle to the given window, using the supplied drawing options.
      *
@@ -161,7 +161,7 @@ namespace splashkit_lib
      * @attribute suffix  with_options
      */
     void draw_triangle_on_window(window destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3, drawing_options opts);
-    
+
     /**
      * Draw a triangle to the given window.
      *
@@ -183,7 +183,7 @@ namespace splashkit_lib
      * @attribute class   window
      */
     void draw_triangle_on_window(window destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3);
-    
+
     /**
      * Draw a triangle on a given window, using the supplied drawing options.
      *
@@ -196,7 +196,7 @@ namespace splashkit_lib
      * @attribute suffix  record_with_options
      */
     void draw_triangle_on_window(window destination, color clr, const triangle &tri, drawing_options opts);
-    
+
     /**
      * Draw a triangle on a given window, using the supplied drawing options.
      *
@@ -208,7 +208,7 @@ namespace splashkit_lib
      * @attribute suffix  record
      */
     void draw_triangle_on_window(window destination, color clr, const triangle &tri);
-    
+
     /**
      * Fill a triangle on a given window, using the supplied drawing options.
      *
@@ -232,7 +232,7 @@ namespace splashkit_lib
      * @attribute suffix  with_options
      */
     void fill_triangle_on_window(window destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3, drawing_options opts);
-    
+
     /**
      * Fill a triangle on a given window
      *
@@ -254,7 +254,7 @@ namespace splashkit_lib
      * @attribute class   window
      */
     void fill_triangle_on_window(window destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3);
-    
+
     /**
      * Fill a triangle on a given window, using given drawing options
      *
@@ -267,7 +267,7 @@ namespace splashkit_lib
      * @attribute suffix  record_with_options
      */
     void fill_triangle_on_window(window destination, color clr, const triangle &tri, drawing_options opts);
-    
+
     /**
      * Fill a triangle on a given window
      *
@@ -279,7 +279,7 @@ namespace splashkit_lib
      * @attribute suffix  record
      */
     void fill_triangle_on_window(window destination, color clr, const triangle &tri);
-    
+
     /**
      * Draw a triangle to the given bitmap, using the supplied drawing options.
      *
@@ -303,7 +303,7 @@ namespace splashkit_lib
      * @attribute suffix  with_options
      */
     void draw_triangle_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3, drawing_options opts);
-    
+
     /**
      * Draw a triangle to the given bitmap.
      *
@@ -325,7 +325,7 @@ namespace splashkit_lib
      * @attribute class   bitmap
      */
     void draw_triangle_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3);
-    
+
     /**
      * Draw a triangle on a given bitmap, using the supplied drawing options.
      *
@@ -338,7 +338,7 @@ namespace splashkit_lib
      * @attribute suffix  record_with_options
      */
     void draw_triangle_on_bitmap(bitmap destination, color clr, const triangle &tri, drawing_options opts);
-    
+
     /**
      * Draw a triangle on a given bitmap, using the supplied drawing options.
      *
@@ -350,7 +350,7 @@ namespace splashkit_lib
      * @attribute suffix  record
      */
     void draw_triangle_on_bitmap(bitmap destination, color clr, const triangle &tri);
-    
+
     /**
      * Fill a triangle on a given bitmap, using the supplied drawing options.
      *
@@ -374,7 +374,7 @@ namespace splashkit_lib
      * @attribute suffix  with_options
      */
     void fill_triangle_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3, drawing_options opts);
-    
+
     /**
      * Fill a triangle on a given bitmap
      *
@@ -396,7 +396,7 @@ namespace splashkit_lib
      * @attribute class   bitmap
      */
     void fill_triangle_on_bitmap(bitmap destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3);
-    
+
     /**
      * Fill a triangle on a given bitmap, using given drawing options
      *
@@ -409,7 +409,7 @@ namespace splashkit_lib
      * @attribute suffix  record_with_options
      */
     void fill_triangle_on_bitmap(bitmap destination, color clr, const triangle &tri, drawing_options opts);
-    
+
     /**
      * Fill a triangle on a given bitmap
      *

--- a/coresdk/src/coresdk/triangle_drawing.h
+++ b/coresdk/src/coresdk/triangle_drawing.h
@@ -136,5 +136,142 @@ namespace splashkit_lib
      * @attribute suffix  record
      */
     void fill_triangle(color clr, const triangle &tri);
+    
+    
+    
+    
+    
+    
+    /**
+     * Draw a triangle to the given window, using the supplied drawing options.
+     *
+     * @param destination The window which the triangle will be drawn on.
+     * @param clr  The color for the triangle
+     * @param x1   The distance from the left side of the bitmap/window to the
+     *             first point of the triangle
+     * @param y1   The distance from the top of the bitmap/window to the
+     *             first point of the triangle
+     * @param x2   The distance from the left side of the bitmap/window to the
+     *             second point of the triangle
+     * @param y2   The distance from the top of the bitmap/window to the
+     *             second point of the triangle
+     * @param x3   The distance from the left side of the bitmap/window to the
+     *             third point of the triangle
+     * @param y3   The distance from the top of the bitmap/window to the
+     *             third point of the triangle
+     * @param opts The drawing options
+     *
+     * @attribute suffix  with_options
+     */
+    void draw_triangle_on_window(window destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3, drawing_options opts);
+    
+    /**
+     * Draw a triangle to the given window.
+     *
+     * @param destination The window which the triangle will be drawn on.
+     * @param clr  The color for the triangle
+     * @param x1   The distance from the left side of the window to the
+     *             first point of the triangle
+     * @param y1   The distance from the top of the window to the
+     *             first point of the triangle
+     * @param x2   The distance from the left side of the window to the
+     *             second point of the triangle
+     * @param y2   The distance from the top of the window to the
+     *             second point of the triangle
+     * @param x3   The distance from the left side of the window to the
+     *             third point of the triangle
+     * @param y3   The distance from the top of the window to the
+     *             third point of the triangle
+     */
+    void draw_triangle_on_window(window destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3);
+    
+    /**
+     * Draw a triangle on a given window, using the supplied drawing options.
+     *
+     * @param destination The window which the triangle will be drawn on.
+     * @param clr  The color for the triangle
+     * @param tri  The triangles details
+     * @param opts The drawing options
+     *
+     * @attribute suffix  record_with_options
+     */
+    void draw_triangle_on_window(window destination, color clr, const triangle &tri, drawing_options opts);
+    
+    /**
+     * Draw a triangle on a given window, using the supplied drawing options.
+     *
+     * @param destination The window which the triangle will be drawn on.
+     * @param clr  The color for the triangle
+     * @param tri  The triangles details
+     *
+     * @attribute suffix  record
+     */
+    void draw_triangle_on_window(window destination, color clr, const triangle &tri);
+    
+    /**
+     * Fill a triangle on a given window, using the supplied drawing options.
+     *
+     * @param destination The window which the triangle will be drawn on.
+     * @param clr  The color for the triangle
+     * @param x1   The distance from the left side of the bitmap/window to the
+     *             first point of the triangle
+     * @param y1   The distance from the top of the bitmap/window to the
+     *             first point of the triangle
+     * @param x2   The distance from the left side of the bitmap/window to the
+     *             second point of the triangle
+     * @param y2   The distance from the top of the bitmap/window to the
+     *             second point of the triangle
+     * @param x3   The distance from the left side of the bitmap/window to the
+     *             third point of the triangle
+     * @param y3   The distance from the top of the bitmap/window to the
+     *             third point of the triangle
+     * @param opts The drawing options
+     *
+     * @attribute suffix  with_options
+     */
+    void fill_triangle_on_window(window destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3, drawing_options opts);
+    
+    /**
+     * Fill a triangle on a given window
+     *
+     * @param destination The window which the triangle will be drawn on.
+     * @param clr  The color for the triangle
+     * @param x1   The distance from the left side of the window to the
+     *             first point of the triangle
+     * @param y1   The distance from the top of the window to the
+     *             first point of the triangle
+     * @param x2   The distance from the left side of the window to the
+     *             second point of the triangle
+     * @param y2   The distance from the top of the window to the
+     *             second point of the triangle
+     * @param x3   The distance from the left side of the window to the
+     *             third point of the triangle
+     * @param y3   The distance from the top of the window to the
+     *             third point of the triangle
+     */
+    void fill_triangle_on_window(window destination, color clr, float x1, float y1, float x2, float y2, float x3, float y3);
+    
+    /**
+     * Fill a triangle on a given window, using given drawing options
+     *
+     * @param destination The window which the triangle will be drawn on.
+     * @param clr  The color for the triangle
+     * @param tri  The triangles details
+     * @param opts The drawing options
+     *
+     * @attribute suffix  record_with_options
+     */
+    void fill_triangle_on_window(window destination, color clr, const triangle &tri, drawing_options opts);
+    
+    /**
+     * Fill a triangle on a given window
+     *
+     * @param destination The window which the triangle will be drawn on.
+     * @param clr  The color for the triangle
+     * @param tri  The triangles details
+     *
+     * @attribute suffix  record
+     */
+    void fill_triangle_on_window(window destination, color clr, const triangle &tri);
 }
 #endif /* triangle_drawing_hpp */


### PR DESCRIPTION
This PR adds class method drawing overloads (`_on_window` and `_on_bitmap`) for:

- rectangle_drawing
- triangle_drawing
- ellipse_drawing
- line_drawing
- point_drawing

As well as a small fix in the web driver which caused memory access exceptions.